### PR TITLE
Add elemental particle classes and shared trait perks

### DIFF
--- a/data/classes/elements/alkali.tres
+++ b/data/classes/elements/alkali.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
+
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+display_name = "Alkali Metal"
+description = "Explosive glass cannon archetype that floods the field with charged bursts."
+element_group = 1
+base_reactivity = 1.15
+base_defense = 0.75
+keywords = ["explosive"]

--- a/data/classes/elements/alkaline_earth.tres
+++ b/data/classes/elements/alkaline_earth.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
+
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+display_name = "Alkaline Earth"
+description = "Durable support chassis that distributes stabilising energy across the squad."
+element_group = 2
+base_reactivity = 1.05
+base_defense = 1.05
+keywords = ["support"]

--- a/data/classes/elements/chalcogen.tres
+++ b/data/classes/elements/chalcogen.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
+
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+display_name = "Chalcogen"
+description = "Corrosive specialist that saturates targets with lingering oxidation."
+element_group = 3
+base_reactivity = 1.1
+base_defense = 0.9
+keywords = ["corrosive"]

--- a/data/classes/elements/halogen.tres
+++ b/data/classes/elements/halogen.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
+
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+display_name = "Halogen"
+description = "Hyper-reactive etching expert that strips armour and chains status effects."
+element_group = 4
+base_reactivity = 1.2
+base_defense = 0.85
+keywords = ["corrosive", "volatile"]

--- a/data/classes/elements/noble_gas.tres
+++ b/data/classes/elements/noble_gas.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
+
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+display_name = "Noble Gas"
+description = "Shield-focused support that projects protective barriers and resists disruption."
+element_group = 5
+base_reactivity = 0.9
+base_defense = 1.2
+keywords = ["support", "heavy_armor"]

--- a/data/classes/elements/radioactive.tres
+++ b/data/classes/elements/radioactive.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
+
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+display_name = "Radioactive"
+description = "Volatile wildcard leveraging contamination and chained detonations."
+element_group = 7
+base_reactivity = 1.3
+base_defense = 0.95
+keywords = ["explosive", "corrosive"]

--- a/data/classes/elements/transition.tres
+++ b/data/classes/elements/transition.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
+
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+display_name = "Transition Metal"
+description = "Heavy armour bruiser with layered plating and momentum control."
+element_group = 6
+base_reactivity = 1.0
+base_defense = 1.25
+keywords = ["heavy_armor"]

--- a/scripts/resources/particle_class.gd
+++ b/scripts/resources/particle_class.gd
@@ -1,0 +1,173 @@
+extends Resource
+class_name ParticleClass
+
+## Resource defining a particle archetype with optional element group affinities.
+## Supports group-wide stat modifiers and trait bundles that can stack with
+## class-specific abilities. Designed for Godot 4.x.
+
+@export var display_name: String = ""
+@export_multiline var description: String = ""
+
+## Enumeration representing elemental behaviour sets.
+enum ElementGroup {
+    NONE,
+    ALKALI,
+    ALKALINE_EARTH,
+    CHALCOGEN,
+    HALOGEN,
+    NOBLE_GAS,
+    TRANSITION,
+    RADIOACTIVE,
+}
+
+@export var element_group: ElementGroup = ElementGroup.NONE setget set_element_group
+
+## Baseline stats supplied by the particle class itself.
+@export var base_reactivity: float = 1.0
+@export var base_defense: float = 1.0
+
+## Optional class specific trait scripts (Script resources that extend Trait).
+@export var class_trait_scripts: Array[Script] = []
+
+## Optional override for group trait scripts. If empty we fall back to the
+## defaults registered in [code]GROUP_TRAIT_SCRIPTS[/code].
+@export var group_trait_scripts: Array[Script] = []
+
+## Additional keywords used to tag playstyle hooks (e.g. "explosive").
+@export var keywords: Array[StringName] = []
+
+const DEFAULT_GROUP_MODIFIER := {
+    "reactivity_multiplier": 1.0,
+    "defense_multiplier": 1.0,
+    "keywords": [],
+}
+
+const GROUP_MODIFIERS := {
+    ElementGroup.ALKALI: {
+        "reactivity_multiplier": 1.35,
+        "defense_multiplier": 0.85,
+        "keywords": ["explosive"],
+    },
+    ElementGroup.ALKALINE_EARTH: {
+        "reactivity_multiplier": 1.1,
+        "defense_multiplier": 1.1,
+        "keywords": ["support"],
+    },
+    ElementGroup.CHALCOGEN: {
+        "reactivity_multiplier": 1.2,
+        "defense_multiplier": 0.95,
+        "keywords": ["corrosive"],
+    },
+    ElementGroup.HALOGEN: {
+        "reactivity_multiplier": 1.3,
+        "defense_multiplier": 0.9,
+        "keywords": ["corrosive"],
+    },
+    ElementGroup.NOBLE_GAS: {
+        "reactivity_multiplier": 0.9,
+        "defense_multiplier": 1.3,
+        "keywords": ["support"],
+    },
+    ElementGroup.TRANSITION: {
+        "reactivity_multiplier": 1.05,
+        "defense_multiplier": 1.35,
+        "keywords": ["heavy_armor"],
+    },
+    ElementGroup.RADIOACTIVE: {
+        "reactivity_multiplier": 1.4,
+        "defense_multiplier": 0.95,
+        "keywords": ["explosive", "corrosive"],
+    },
+}
+
+const GROUP_TRAIT_SCRIPTS := {
+    ElementGroup.ALKALI: [
+        preload("res://scripts/traits/alkali_overload.gd"),
+    ],
+    ElementGroup.ALKALINE_EARTH: [
+        preload("res://scripts/traits/alkaline_reservoir.gd"),
+    ],
+    ElementGroup.CHALCOGEN: [
+        preload("res://scripts/traits/chalcogen_corrosion.gd"),
+    ],
+    ElementGroup.HALOGEN: [
+        preload("res://scripts/traits/halogen_etching.gd"),
+    ],
+    ElementGroup.NOBLE_GAS: [
+        preload("res://scripts/traits/noble_shield.gd"),
+    ],
+    ElementGroup.TRANSITION: [
+        preload("res://scripts/traits/transition_plating.gd"),
+    ],
+    ElementGroup.RADIOACTIVE: [
+        preload("res://scripts/traits/radioactive_meltdown.gd"),
+    ],
+}
+
+func set_element_group(value: ElementGroup) -> void:
+    element_group = value
+    # When the group changes we clear any previously assigned overrides so the
+    # new default perks are used unless explicitly overridden again.
+    if group_trait_scripts.is_empty():
+        return
+    group_trait_scripts.clear()
+
+func get_group_modifiers() -> Dictionary:
+    return GROUP_MODIFIERS.get(element_group, DEFAULT_GROUP_MODIFIER)
+
+func get_group_keywords() -> Array[StringName]:
+    var result: Array[StringName] = []
+    for keyword in keywords:
+        if keyword not in result:
+            result.append(keyword)
+    var group_data := get_group_modifiers()
+    for keyword in group_data.get("keywords", []):
+        if keyword not in result:
+            result.append(keyword)
+    return result
+
+func get_default_group_trait_scripts() -> Array[Script]:
+    return GROUP_TRAIT_SCRIPTS.get(element_group, [])
+
+func get_all_trait_scripts(extra_traits: Array[Script] = []) -> Array[Script]:
+    var scripts: Array[Script] = []
+    scripts.append_array(class_trait_scripts)
+    if group_trait_scripts.is_empty():
+        scripts.append_array(get_default_group_trait_scripts())
+    else:
+        scripts.append_array(group_trait_scripts)
+    scripts.append_array(extra_traits)
+    return scripts
+
+func get_effective_stats(extra_traits: Array[Script] = [], context: Dictionary = {}) -> Dictionary:
+    var modifiers := get_group_modifiers()
+    var stats := {
+        "reactivity": base_reactivity * modifiers.get("reactivity_multiplier", 1.0),
+        "defense": base_defense * modifiers.get("defense_multiplier", 1.0),
+        "keywords": get_group_keywords(),
+    }
+
+    for trait_script in get_all_trait_scripts(extra_traits):
+        if trait_script == null:
+            continue
+        var trait := trait_script.new()
+        if not trait:
+            continue
+        if not trait.has_method("apply"):
+            push_warning("Trait %s is missing an apply() method" % [trait_script.resource_path])
+            continue
+        stats = trait.apply(stats, context)
+    return stats
+
+func describe() -> String:
+    var modifiers := get_group_modifiers()
+    var lines := []
+    lines.append("Group: %s" % ElementGroup.keys()[element_group])
+    lines.append("Base Reactivity: %.2f (x%.2f group)" % [base_reactivity, modifiers.get("reactivity_multiplier", 1.0)])
+    lines.append("Base Defense: %.2f (x%.2f group)" % [base_defense, modifiers.get("defense_multiplier", 1.0)])
+    if not keywords.is_empty():
+        lines.append("Class Keywords: %s" % ", ".join(keywords))
+    var group_keywords := get_group_keywords()
+    if not group_keywords.is_empty():
+        lines.append("Group Keywords: %s" % ", ".join(group_keywords))
+    return "\n".join(lines)

--- a/scripts/traits/alkali_overload.gd
+++ b/scripts/traits/alkali_overload.gd
@@ -1,0 +1,32 @@
+extends "res://scripts/traits/trait.gd"
+class_name AlkaliOverload
+
+const REACTIVITY_MULTIPLIER := 1.25
+const REACTIVITY_BONUS := 0.35
+const DEFENSE_MULTIPLIER := 0.8
+
+func _init() -> void:
+    id = "alkali_overload"
+    display_name = "Alkali Overload"
+    description = "Unstable charge releases explosive bursts, massively raising reactivity while trading away plating."
+
+func apply(stats: Dictionary, context: Dictionary = {}) -> Dictionary:
+    var result := stats.duplicate(true)
+    var keywords: Array = result.get("keywords", []).duplicate()
+    if "explosive" not in keywords:
+        keywords.append("explosive")
+    result["keywords"] = keywords
+
+    var reactivity := result.get("reactivity", 1.0)
+    reactivity *= REACTIVITY_MULTIPLIER
+    reactivity += REACTIVITY_BONUS
+    result["reactivity"] = reactivity
+
+    var defense := result.get("defense", 1.0)
+    defense *= DEFENSE_MULTIPLIER
+    result["defense"] = max(defense, 0.0)
+
+    var bursts := result.get("burst_damage", 0.0)
+    bursts += REACTIVITY_BONUS * 2.0
+    result["burst_damage"] = bursts
+    return result

--- a/scripts/traits/alkaline_reservoir.gd
+++ b/scripts/traits/alkaline_reservoir.gd
@@ -1,0 +1,26 @@
+extends "res://scripts/traits/trait.gd"
+class_name AlkalineReservoir
+
+const REGEN_BONUS := 0.2
+const DEFENSE_MULTIPLIER := 1.15
+const TEAM_BUFF := 0.1
+
+func _init() -> void:
+    id = "alkaline_reservoir"
+    display_name = "Alkaline Reservoir"
+    description = "Stabilising lattice grants steady ion reserves, bolstering team recovery and plating."
+
+func apply(stats: Dictionary, context: Dictionary = {}) -> Dictionary:
+    var result := stats.duplicate(true)
+    var keywords: Array = result.get("keywords", []).duplicate()
+    if "support" not in keywords:
+        keywords.append("support")
+    result["keywords"] = keywords
+
+    result["defense"] = result.get("defense", 1.0) * DEFENSE_MULTIPLIER
+    result["reactivity_regen"] = result.get("reactivity_regen", 0.0) + REGEN_BONUS
+
+    var team_support := result.get("team_support", 0.0)
+    team_support += TEAM_BUFF
+    result["team_support"] = team_support
+    return result

--- a/scripts/traits/chalcogen_corrosion.gd
+++ b/scripts/traits/chalcogen_corrosion.gd
@@ -1,0 +1,21 @@
+extends "res://scripts/traits/trait.gd"
+class_name ChalcogenCorrosion
+
+const DAMAGE_OVER_TIME := 0.25
+const DEFENSE_PIERCING := 0.1
+
+func _init() -> void:
+    id = "chalcogen_corrosion"
+    display_name = "Chalcogen Corrosion"
+    description = "Reactive oxidisers chew through foes with lingering corrosion while ignoring a portion of armour."
+
+func apply(stats: Dictionary, context: Dictionary = {}) -> Dictionary:
+    var result := stats.duplicate(true)
+    var keywords: Array = result.get("keywords", []).duplicate()
+    if "corrosive" not in keywords:
+        keywords.append("corrosive")
+    result["keywords"] = keywords
+
+    result["damage_over_time"] = result.get("damage_over_time", 0.0) + DAMAGE_OVER_TIME
+    result["armor_pierce"] = result.get("armor_pierce", 0.0) + DEFENSE_PIERCING
+    return result

--- a/scripts/traits/halogen_etching.gd
+++ b/scripts/traits/halogen_etching.gd
@@ -1,0 +1,32 @@
+extends "res://scripts/traits/trait.gd"
+class_name HalogenEtching
+
+const REACTIVITY_MULTIPLIER := 1.15
+const DEFENSE_SHRED := 0.15
+const STATUS_DURATION := 2.0
+
+func _init() -> void:
+    id = "halogen_etching"
+    display_name = "Halogen Etching"
+    description = "Highly electronegative halogens etch defences, increasing reactivity and applying stacking armour shred."
+
+func apply(stats: Dictionary, context: Dictionary = {}) -> Dictionary:
+    var result := stats.duplicate(true)
+    var keywords: Array = result.get("keywords", []).duplicate()
+    if "corrosive" not in keywords:
+        keywords.append("corrosive")
+    if "explosive" in keywords and "volatile" not in keywords:
+        keywords.append("volatile")
+    result["keywords"] = keywords
+
+    result["reactivity"] = result.get("reactivity", 1.0) * REACTIVITY_MULTIPLIER
+
+    var shred := result.get("enemy_armor_shred", 0.0)
+    shred += DEFENSE_SHRED
+    result["enemy_armor_shred"] = shred
+
+    var status := result.get("status_durations", {})
+    status = status.duplicate()
+    status["etching"] = status.get("etching", 0.0) + STATUS_DURATION
+    result["status_durations"] = status
+    return result

--- a/scripts/traits/noble_shield.gd
+++ b/scripts/traits/noble_shield.gd
@@ -1,0 +1,23 @@
+extends "res://scripts/traits/trait.gd"
+class_name NobleShield
+
+const DEFENSE_MULTIPLIER := 1.35
+const TEAM_WARD := 0.2
+
+func _init() -> void:
+    id = "noble_shield"
+    display_name = "Noble Shield"
+    description = "Inert noble gases project stabilising barriers, granting heavy warding to allies without sacrificing focus."
+
+func apply(stats: Dictionary, context: Dictionary = {}) -> Dictionary:
+    var result := stats.duplicate(true)
+    var keywords: Array = result.get("keywords", []).duplicate()
+    if "support" not in keywords:
+        keywords.append("support")
+    if "heavy_armor" not in keywords:
+        keywords.append("heavy_armor")
+    result["keywords"] = keywords
+
+    result["defense"] = result.get("defense", 1.0) * DEFENSE_MULTIPLIER
+    result["team_barrier"] = result.get("team_barrier", 0.0) + TEAM_WARD
+    return result

--- a/scripts/traits/radioactive_meltdown.gd
+++ b/scripts/traits/radioactive_meltdown.gd
@@ -1,0 +1,29 @@
+extends "res://scripts/traits/trait.gd"
+class_name RadioactiveMeltdown
+
+const REACTIVITY_MULTIPLIER := 1.4
+const DEFENSE_MULTIPLIER := 0.9
+const CORRUPTION_BONUS := 0.3
+const EXPLOSION_RADIUS := 1.5
+
+func _init() -> void:
+    id = "radioactive_meltdown"
+    display_name = "Radioactive Meltdown"
+    description = "Unstable isotopes surge with corruptive energy, spreading contamination and empowering last-resort detonations."
+
+func apply(stats: Dictionary, context: Dictionary = {}) -> Dictionary:
+    var result := stats.duplicate(true)
+    var keywords: Array = result.get("keywords", []).duplicate()
+    for keyword in ["explosive", "corrosive"]:
+        if keyword not in keywords:
+            keywords.append(keyword)
+    if "contagion" not in keywords:
+        keywords.append("contagion")
+    result["keywords"] = keywords
+
+    result["reactivity"] = result.get("reactivity", 1.0) * REACTIVITY_MULTIPLIER
+    result["defense"] = max(0.0, result.get("defense", 1.0) * DEFENSE_MULTIPLIER)
+
+    result["contagion_strength"] = result.get("contagion_strength", 0.0) + CORRUPTION_BONUS
+    result["explosion_radius"] = result.get("explosion_radius", 1.0) * EXPLOSION_RADIUS
+    return result

--- a/scripts/traits/trait.gd
+++ b/scripts/traits/trait.gd
@@ -1,0 +1,21 @@
+extends Resource
+class_name Trait
+
+## Base class for particle traits that can modify stats or inject passive
+## gameplay hooks. Traits are designed to be stateless singletons that mutate a
+## passed in dictionary to support deterministic stacking behaviour.
+
+@export var id: StringName = ""
+@export var display_name: String = ""
+@export_multiline var description: String = ""
+
+func apply(stats: Dictionary, context: Dictionary = {}) -> Dictionary:
+    ## Default implementation returns the stats unchanged.
+    return stats
+
+func get_keywords() -> Array[StringName]:
+    return []
+
+func stacks_with(other_id: StringName) -> bool:
+    ## By default traits stack with everything including duplicates.
+    return true

--- a/scripts/traits/transition_plating.gd
+++ b/scripts/traits/transition_plating.gd
@@ -1,0 +1,26 @@
+extends "res://scripts/traits/trait.gd"
+class_name TransitionPlating
+
+const DEFENSE_MULTIPLIER := 1.4
+const STABILITY_BONUS := 0.15
+const REACTIVITY_TAX := -0.05
+
+func _init() -> void:
+    id = "transition_plating"
+    display_name = "Transition Plating"
+    description = "Dense metallic matrices add layered plating and stability, enabling heavy armour builds."
+
+func apply(stats: Dictionary, context: Dictionary = {}) -> Dictionary:
+    var result := stats.duplicate(true)
+    var keywords: Array = result.get("keywords", []).duplicate()
+    if "heavy_armor" not in keywords:
+        keywords.append("heavy_armor")
+    result["keywords"] = keywords
+
+    result["defense"] = result.get("defense", 1.0) * DEFENSE_MULTIPLIER
+    result["stability"] = result.get("stability", 0.0) + STABILITY_BONUS
+
+    var reactivity := result.get("reactivity", 1.0)
+    reactivity += REACTIVITY_TAX
+    result["reactivity"] = max(reactivity, 0.0)
+    return result


### PR DESCRIPTION
## Summary
- add a ParticleClass resource that tracks element groups, group stat modifiers, and combined trait stacks
- create elemental archetype data resources for each major chemistry group with descriptive stat baselines
- implement group perk trait scripts such as Alkali Overload and Noble Shield to provide shared bonuses

## Testing
- not run (Godot resources only)


------
https://chatgpt.com/codex/tasks/task_e_68e1a026bd1483298a79a792fe2dbf5c