### PR TITLE
Add particle classes and abilities

### DIFF
--- a/data/classes/particles/down_quark.tres
+++ b/data/classes/particles/down_quark.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/abilities/downward_smash.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/abilities/mass_anchor.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/abilities/baryon_wall.gd" id="4"]
+
+[resource]
+script = ExtResource("1")
+id = "down_quark"
+display_name = "Down Quark"
+description = "Heavier partner that soaks hits and helps assemble hadronic power moves. Slow but relentless." 
+mass = 0.0047
+charge = -0.3333
+stability = 0.9
+active_ability = ExtResource("2")
+passive_ability = ExtResource("3")
+ultimate_ability = ExtResource("4")

--- a/data/classes/particles/electron.tres
+++ b/data/classes/particles/electron.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/abilities/orbital_strike.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/abilities/ion_field.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/abilities/chain_discharge.gd" id="4"]
+
+[resource]
+script = ExtResource("1")
+id = "electron"
+display_name = "Electron"
+description = "Agile charged particle. Orbits objectives, darts through conduits, and chains lightning across foes."
+mass = 0.000511
+charge = -1.0
+stability = 1.0
+active_ability = ExtResource("2")
+passive_ability = ExtResource("3")
+ultimate_ability = ExtResource("4")

--- a/data/classes/particles/electron_neutrino.tres
+++ b/data/classes/particles/electron_neutrino.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/abilities/phase_shift.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/abilities/ghost_walk.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/abilities/weak_flux.gd" id="4"]
+
+[resource]
+script = ExtResource("1")
+id = "electron_neutrino"
+display_name = "Electron Neutrino"
+description = "Ghostly infiltrator. Barely interacts, phasing through barriers while unleashing precise weak-force bursts."
+mass = 0.00001
+charge = 0.0
+stability = 1.0
+active_ability = ExtResource("2")
+passive_ability = ExtResource("3")
+ultimate_ability = ExtResource("4")

--- a/data/classes/particles/gluon.tres
+++ b/data/classes/particles/gluon.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/abilities/gluon_bind.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/abilities/color_field.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/abilities/fusion_lock.gd" id="4"]
+
+[resource]
+script = ExtResource("1")
+id = "gluon"
+display_name = "Gluon"
+description = "Strong-force specialist. Binds allies together, locking down enemies with colourful tethers."
+mass = 0.0
+charge = 0.0
+stability = 0.7
+active_ability = ExtResource("2")
+passive_ability = ExtResource("3")
+ultimate_ability = ExtResource("4")

--- a/data/classes/particles/higgs_boson.tres
+++ b/data/classes/particles/higgs_boson.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/abilities/higgs_mass_boost.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/abilities/inertial_field.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/abilities/higgs_resonance.gd" id="4"]
+
+[resource]
+script = ExtResource("1")
+id = "higgs_boson"
+display_name = "Higgs Boson"
+description = "Mythic support. Awakens latent mass, bolstering allies with inertia and resonance-fuelled empowerment."
+mass = 125.10
+charge = 0.0
+stability = 0.3
+active_ability = ExtResource("2")
+passive_ability = ExtResource("3")
+ultimate_ability = ExtResource("4")

--- a/data/classes/particles/photon.tres
+++ b/data/classes/particles/photon.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/abilities/photon_pulse.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/abilities/refraction_cloak.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/abilities/gamma_burst.gd" id="4"]
+
+[resource]
+script = ExtResource("1")
+id = "photon"
+display_name = "Photon"
+description = "Glass-cannon beam of light. Moves at blinding speed, solves optical puzzles, but pays with fragile defences."
+mass = 0.0
+charge = 0.0
+stability = 0.85
+active_ability = ExtResource("2")
+passive_ability = ExtResource("3")
+ultimate_ability = ExtResource("4")

--- a/data/classes/particles/up_quark.tres
+++ b/data/classes/particles/up_quark.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/abilities/color_dash.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/abilities/fractional_charge.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/abilities/hadronize.gd" id="4"]
+
+[resource]
+script = ExtResource("1")
+id = "up_quark"
+display_name = "Up Quark"
+description = "Lightweight and evasive. Exploits fractional charge to dart through electromagnetic puzzles and set up combo finishers."
+mass = 0.0022
+charge = 0.6667
+stability = 0.95
+active_ability = ExtResource("2")
+passive_ability = ExtResource("3")
+ultimate_ability = ExtResource("4")

--- a/data/classes/particles/w_boson.tres
+++ b/data/classes/particles/w_boson.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/abilities/w_blast.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/abilities/weak_charge_field.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/abilities/beta_decay.gd" id="4"]
+
+[resource]
+script = ExtResource("1")
+id = "w_boson"
+display_name = "W Boson"
+description = "Massive weak-force carrier. Devastating charges with self-damaging recoil – risky but explosive."
+mass = 80.379
+charge = 1.0
+stability = 0.2
+active_ability = ExtResource("2")
+passive_ability = ExtResource("3")
+ultimate_ability = ExtResource("4")

--- a/data/classes/particles/z_boson.tres
+++ b/data/classes/particles/z_boson.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/abilities/z_pulse.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/abilities/neutral_screen.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/abilities/annihilation_wave.gd" id="4"]
+
+[resource]
+script = ExtResource("1")
+id = "z_boson"
+display_name = "Z Boson"
+description = "Neutral weak-force titan. Trades mobility for massive neutral blasts that punish both sides of a fight."
+mass = 91.1876
+charge = 0.0
+stability = 0.25
+active_ability = ExtResource("2")
+passive_ability = ExtResource("3")
+ultimate_ability = ExtResource("4")

--- a/scenes/player/player_avatar.tscn
+++ b/scenes/player/player_avatar.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/player/player_avatar.gd" id="1"]
+[ext_resource type="Resource" path="res://data/classes/particles/up_quark.tres" id="2"]
+
+[node name="PlayerAvatar" type="CharacterBody2D"]
+script = ExtResource("1")
+particle_class = ExtResource("2")

--- a/scripts/abilities/annihilation_wave.gd
+++ b/scripts/abilities/annihilation_wave.gd
@@ -1,0 +1,31 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Annihilation Wave"
+    cooldown = 25.0
+    activation_duration = 3.0
+    description = "Fire a neutral current that vaporises foes but collapses shields afterwards." \
+        + " A risky finisher."
+    activation_profile = {
+        "bonuses": {
+            "damage": 1.4,
+        },
+        "multipliers": {
+            "defense": 1.1,
+        },
+        "keywords": ["neutral", "annihilation"],
+    }
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    var details := super.activate(player, context)
+    if details.get("success", false):
+        player.apply_temporary_profile(self, {
+            "bonuses": {
+                "shield": -100.0,
+            },
+            "multipliers": {
+                "defense": 0.7,
+            },
+        }, activation_duration + 2.5)
+        details["log"] = "Annihilation Wave clears the field – structural integrity plummets."
+    return details

--- a/scripts/abilities/baryon_wall.gd
+++ b/scripts/abilities/baryon_wall.gd
@@ -1,0 +1,19 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Baryon Wall"
+    cooldown = 20.0
+    activation_duration = 8.0
+    description = "Lock neighbouring quarks into a defensive lattice, dramatically raising shielding and defense." \
+        + " Slightly slows movement while active."
+    activation_profile = {
+        "bonuses": {
+            "shield": 120.0,
+        },
+        "multipliers": {
+            "defense": 1.5,
+            "speed": 0.75,
+        },
+        "keywords": ["fortress", "bound"],
+    }
+    activation_log_message = "Baryon Wall formed – incoming momentum absorbed."

--- a/scripts/abilities/beta_decay.gd
+++ b/scripts/abilities/beta_decay.gd
@@ -1,0 +1,34 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+@export var collapse_penalty: float = 0.4
+
+func _init() -> void:
+    ability_name = "Beta Cascade"
+    cooldown = 24.0
+    activation_duration = 4.5
+    description = "Trigger a destructive weak-force cascade, obliterating foes at the cost of severe recoil." \
+        + " Leaves stability shattered."
+    activation_profile = {
+        "bonuses": {
+            "damage": 1.2,
+        },
+        "multipliers": {
+            "speed": 1.1,
+        },
+        "keywords": ["weak_force", "cascade"],
+    }
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    var details := super.activate(player, context)
+    if details.get("success", false):
+        player.apply_temporary_profile(self, {
+            "multipliers": {
+                "defense": 1.0 - collapse_penalty,
+            },
+            "bonuses": {
+                "shield": -60.0,
+            },
+        }, activation_duration + 3.0)
+        details["collapse_penalty"] = collapse_penalty
+        details["log"] = "Beta Cascade erupts – systems collapse by %d%% afterwards." % int(collapse_penalty * 100.0)
+    return details

--- a/scripts/abilities/chain_discharge.gd
+++ b/scripts/abilities/chain_discharge.gd
@@ -1,0 +1,33 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Chain Discharge"
+    cooldown = 16.0
+    activation_duration = 4.0
+    description = "Rapidly arc between foes, massively boosting damage while draining shields afterwards." \
+        + " Requires precise timing to avoid vulnerability."
+    activation_profile = {
+        "bonuses": {
+            "damage": 0.75,
+            "shield": 30.0,
+        },
+        "multipliers": {
+            "control": 1.4,
+        },
+        "keywords": ["chain", "conductive"],
+    }
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    var result := super.activate(player, context)
+    if result.get("success", false):
+        # Schedule a post-activation penalty by applying a negative shield profile once the boost fades.
+        player.apply_temporary_profile(self, {
+            "bonuses": {
+                "shield": -40.0,
+            },
+            "multipliers": {
+                "defense": 0.85,
+            },
+        }, activation_duration + 0.1)
+        result["log"] = "Chain Discharge arcs wildly – shields destabilise afterwards."
+    return result

--- a/scripts/abilities/color_dash.gd
+++ b/scripts/abilities/color_dash.gd
@@ -1,0 +1,19 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Color Dash"
+    cooldown = 6.0
+    activation_duration = 2.0
+    description = "Accelerate into a blur of colour charge, phasing past hazards." \
+        + " Temporarily boosts speed and evasion while reducing control."
+    activation_profile = {
+        "bonuses": {
+            "speed": 160.0,
+        },
+        "multipliers": {
+            "control": 0.6,
+            "evasion": 1.35,
+        },
+        "keywords": ["phased", "fast"],
+    }
+    activation_log_message = "Color Dash engaged: momentum conserved through phase space."

--- a/scripts/abilities/color_field.gd
+++ b/scripts/abilities/color_field.gd
@@ -1,0 +1,15 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Color Field"
+    description = "Ambient strong-force aura grants allies minor shields and resistance to pulls." \
+        + " Ideal for cooperative formations."
+    persistent_profile = {
+        "bonuses": {
+            "shield": 25.0,
+        },
+        "multipliers": {
+            "defense": 1.15,
+        },
+        "keywords": ["binding", "support"],
+    }

--- a/scripts/abilities/downward_smash.gd
+++ b/scripts/abilities/downward_smash.gd
@@ -1,0 +1,19 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Downward Smash"
+    cooldown = 7.0
+    activation_duration = 2.5
+    description = "Convert heft into a seismic slam. Hits hard but momentarily reduces mobility." \
+        + " Excellent for cracking armour." 
+    activation_profile = {
+        "bonuses": {
+            "damage": 0.5,
+        },
+        "multipliers": {
+            "speed": 0.65,
+            "control": 0.8,
+        },
+        "keywords": ["heavy", "impact"],
+    }
+    activation_log_message = "Downward Smash rattles the arena with colour-neutral force."

--- a/scripts/abilities/fractional_charge.gd
+++ b/scripts/abilities/fractional_charge.gd
@@ -1,0 +1,16 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Fractional Charge"
+    description = "Up quark charge tricks electromagnetic puzzles. Increases agility and reaction damage." \
+        + " Adds the 'charged' keyword for synergy triggers."
+    persistent_profile = {
+        "bonuses": {
+            "speed": 40.0,
+        },
+        "multipliers": {
+            "damage": 1.1,
+            "evasion": 1.15,
+        },
+        "keywords": ["charged", "evasive"],
+    }

--- a/scripts/abilities/fusion_lock.gd
+++ b/scripts/abilities/fusion_lock.gd
@@ -1,0 +1,19 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Fusion Lock"
+    cooldown = 19.0
+    activation_duration = 7.0
+    description = "Forge a protective fusion lattice. Greatly increases defence and grants the binding keyword." \
+        + " Movement slows while maintaining the lock."
+    activation_profile = {
+        "bonuses": {
+            "shield": 90.0,
+        },
+        "multipliers": {
+            "defense": 1.6,
+            "speed": 0.8,
+        },
+        "keywords": ["binding", "fortified"],
+    }
+    activation_log_message = "Fusion Lock weaves allies into a resilient shell."

--- a/scripts/abilities/gamma_burst.gd
+++ b/scripts/abilities/gamma_burst.gd
@@ -1,0 +1,31 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Gamma Burst"
+    cooldown = 22.0
+    activation_duration = 3.5
+    description = "Release a devastating gamma flash. Massive damage spike with a steep stability penalty afterwards." \
+        + " Use only when escape is assured."
+    activation_profile = {
+        "bonuses": {
+            "damage": 1.1,
+        },
+        "multipliers": {
+            "speed": 1.4,
+        },
+        "keywords": ["light", "gamma"],
+    }
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    var details := super.activate(player, context)
+    if details.get("success", false):
+        player.apply_temporary_profile(self, {
+            "bonuses": {
+                "shield": -80.0,
+            },
+            "multipliers": {
+                "defense": 0.6,
+            },
+        }, activation_duration + 2.0)
+        details["log"] = "Gamma Burst annihilates targets – defences collapse afterwards."
+    return details

--- a/scripts/abilities/ghost_walk.gd
+++ b/scripts/abilities/ghost_walk.gd
@@ -1,0 +1,14 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Ghost Walk"
+    description = "Neutrino barely interacts – permanent stealth bonus and resistance to binding."
+    persistent_profile = {
+        "bonuses": {
+            "stealth": 0.6,
+        },
+        "multipliers": {
+            "evasion": 1.25,
+        },
+        "keywords": ["stealth", "untetherable"],
+    }

--- a/scripts/abilities/gluon_bind.gd
+++ b/scripts/abilities/gluon_bind.gd
@@ -1,0 +1,26 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+@export var tether_strength: float = 0.8
+
+func _init() -> void:
+    ability_name = "Gluon Bind"
+    cooldown = 9.0
+    activation_duration = 5.0
+    description = "Project a strong-force tether that links allies or snares foes, boosting defence while active." \
+        + " Enemies struggle to escape the colour flux."
+    activation_profile = {
+        "bonuses": {
+            "shield": 45.0,
+        },
+        "multipliers": {
+            "defense": 1.25,
+        },
+        "keywords": ["binding", "support"],
+    }
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    var details := super.activate(player, context)
+    if details.get("success", false):
+        details["tether_strength"] = tether_strength
+        details["log"] = "Gluon Bind forms a colour flux tether (strength %0.2f)." % tether_strength
+    return details

--- a/scripts/abilities/hadronize.gd
+++ b/scripts/abilities/hadronize.gd
@@ -1,0 +1,19 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Hadronize"
+    cooldown = 18.0
+    activation_duration = 6.0
+    description = "Summon a momentary baryon partner, boosting damage while adding a thin shield." \
+        + " Perfect for finishing bursts after building momentum."
+    activation_profile = {
+        "bonuses": {
+            "damage": 0.4,
+            "shield": 40.0,
+        },
+        "multipliers": {
+            "control": 0.9,
+        },
+        "keywords": ["combo", "paired"],
+    }
+    activation_log_message = "Hadron duo assembled – composite attack online."

--- a/scripts/abilities/higgs_mass_boost.gd
+++ b/scripts/abilities/higgs_mass_boost.gd
@@ -1,0 +1,19 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Mass Infusion"
+    cooldown = 11.0
+    activation_duration = 6.0
+    description = "Channel the Higgs field to increase mass and defence for allies while slowing movement." \
+        + " Great for prepping heavy attacks."
+    activation_profile = {
+        "bonuses": {
+            "shield": 60.0,
+        },
+        "multipliers": {
+            "defense": 1.4,
+            "speed": 0.85,
+        },
+        "keywords": ["higgs", "empower"],
+    }
+    activation_log_message = "Mass Infusion bathes the squad in Higgs energy."

--- a/scripts/abilities/higgs_resonance.gd
+++ b/scripts/abilities/higgs_resonance.gd
@@ -1,0 +1,31 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Higgs Resonance"
+    cooldown = 26.0
+    activation_duration = 8.0
+    description = "Enter a resonance that massively boosts allied stats, then slowly returns them to normal." \
+        + " Signature support ultimate."
+    activation_profile = {
+        "bonuses": {
+            "damage": 0.6,
+            "shield": 80.0,
+        },
+        "multipliers": {
+            "defense": 1.4,
+            "speed": 1.1,
+        },
+        "keywords": ["higgs", "resonance"],
+    }
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    var result := super.activate(player, context)
+    if result.get("success", false):
+        player.apply_temporary_profile(self, {
+            "multipliers": {
+                "damage": 0.85,
+                "speed": 0.95,
+            },
+        }, activation_duration + 4.0)
+        result["log"] = "Higgs Resonance peaks then gently cools the field."
+    return result

--- a/scripts/abilities/inertial_field.gd
+++ b/scripts/abilities/inertial_field.gd
@@ -1,0 +1,16 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Inertial Field"
+    description = "Persistent Higgs aura raises baseline stability and shield regeneration." \
+        + " Slightly reduces top speed due to extra inertia."
+    persistent_profile = {
+        "bonuses": {
+            "shield": 40.0,
+        },
+        "multipliers": {
+            "defense": 1.2,
+            "speed": 0.9,
+        },
+        "keywords": ["higgs", "support"],
+    }

--- a/scripts/abilities/ion_field.gd
+++ b/scripts/abilities/ion_field.gd
@@ -1,0 +1,15 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Ion Field"
+    description = "Electron cloud wraps the avatar, improving control and granting minor shielding." \
+        + " Adds the 'conductive' keyword for puzzle hooks."
+    persistent_profile = {
+        "bonuses": {
+            "shield": 15.0,
+        },
+        "multipliers": {
+            "control": 1.2,
+        },
+        "keywords": ["conductive", "agile"],
+    }

--- a/scripts/abilities/mass_anchor.gd
+++ b/scripts/abilities/mass_anchor.gd
@@ -1,0 +1,16 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Mass Anchor"
+    description = "Down quark density bolsters stability, reducing knockback and bolstering shielding." \
+        + " Trades away a little agility for toughness."
+    persistent_profile = {
+        "bonuses": {
+            "shield": 35.0,
+        },
+        "multipliers": {
+            "defense": 1.25,
+            "speed": 0.9,
+        },
+        "keywords": ["anchor", "sturdy"],
+    }

--- a/scripts/abilities/neutral_screen.gd
+++ b/scripts/abilities/neutral_screen.gd
@@ -1,0 +1,16 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Neutral Screen"
+    description = "Z boson's neutrality dampens incoming forces, improving defence at the cost of mobility." \
+        + " Ideal for tanking anomalies."
+    persistent_profile = {
+        "bonuses": {
+            "shield": 30.0,
+        },
+        "multipliers": {
+            "defense": 1.35,
+            "speed": 0.85,
+        },
+        "keywords": ["neutral", "tank"],
+    }

--- a/scripts/abilities/orbital_strike.gd
+++ b/scripts/abilities/orbital_strike.gd
@@ -1,0 +1,19 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Orbital Strike"
+    cooldown = 5.5
+    activation_duration = 1.8
+    description = "Zip around a target and unleash an electron spiral, boosting damage and control briefly." \
+        + " Restores a little shield on hit." 
+    activation_profile = {
+        "bonuses": {
+            "damage": 0.35,
+            "shield": 20.0,
+        },
+        "multipliers": {
+            "control": 1.3,
+        },
+        "keywords": ["orbit", "charged"],
+    }
+    activation_log_message = "Orbital Strike discharges across the lattice."

--- a/scripts/abilities/particle_ability.gd
+++ b/scripts/abilities/particle_ability.gd
@@ -1,0 +1,45 @@
+extends Resource
+class_name ParticleAbility
+
+@export var ability_name: String = ""
+@export_multiline var description: String = ""
+@export var cooldown: float = 0.0
+@export var activation_duration: float = 0.0
+@export var activation_profile: Dictionary = {}
+@export var activation_keywords: Array[StringName] = []
+@export var persistent_profile: Dictionary = {}
+@export var activation_log_message: String = ""
+
+var slot: StringName = &""
+
+func on_equip(player: PlayerAvatar) -> void:
+    if not persistent_profile.is_empty():
+        player.apply_stat_profile(self, persistent_profile)
+
+func on_unequip(player: PlayerAvatar) -> void:
+    player.remove_stat_profile(self)
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    if activation_profile.is_empty():
+        return {
+            "log": "%s is ready." % ability_name,
+            "success": false,
+        }
+    var profile := activation_profile.duplicate(true)
+    if not activation_keywords.is_empty():
+        var keywords := profile.get("keywords", [])
+        for keyword in activation_keywords:
+            if keyword not in keywords:
+                keywords.append(keyword)
+        profile["keywords"] = keywords
+    var duration := max(activation_duration, 0.0)
+    if duration > 0.0:
+        player.apply_temporary_profile(self, profile, duration)
+    else:
+        player.apply_stat_profile(self, profile)
+    var message := activation_log_message if activation_log_message != "" else "%s activated." % ability_name
+    return {
+        "log": message,
+        "success": true,
+        "duration": duration,
+    }

--- a/scripts/abilities/phase_shift.gd
+++ b/scripts/abilities/phase_shift.gd
@@ -1,0 +1,19 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Phase Shift"
+    cooldown = 8.0
+    activation_duration = 3.0
+    description = "Slip out of phase with matter, ignoring collisions while reducing outgoing damage." \
+        + " Perfect infiltration tool."
+    activation_profile = {
+        "bonuses": {
+            "stealth": 1.0,
+        },
+        "multipliers": {
+            "damage": 0.6,
+            "evasion": 1.5,
+        },
+        "keywords": ["intangible", "stealth"],
+    }
+    activation_log_message = "Phase Shift renders the neutrino ghostlike."

--- a/scripts/abilities/photon_pulse.gd
+++ b/scripts/abilities/photon_pulse.gd
@@ -1,0 +1,31 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Photon Pulse"
+    cooldown = 4.5
+    activation_duration = 1.5
+    description = "Explode forward at light-speed, spiking damage but shedding shields." \
+        + " Classic glass-cannon burst."
+    activation_profile = {
+        "bonuses": {
+            "damage": 0.55,
+        },
+        "multipliers": {
+            "speed": 1.6,
+        },
+        "keywords": ["light", "burst"],
+    }
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    var outcome := super.activate(player, context)
+    if outcome.get("success", false):
+        player.apply_temporary_profile(self, {
+            "bonuses": {
+                "shield": -30.0,
+            },
+            "multipliers": {
+                "defense": 0.8,
+            },
+        }, activation_duration + 0.5)
+        outcome["log"] = "Photon Pulse scorches forward – defences flare out."
+    return outcome

--- a/scripts/abilities/refraction_cloak.gd
+++ b/scripts/abilities/refraction_cloak.gd
@@ -1,0 +1,16 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Refraction Cloak"
+    description = "Wrap in refracted light, upping speed but leaving defences fragile." \
+        + " Maintains glass-cannon identity."
+    persistent_profile = {
+        "bonuses": {
+            "speed": 80.0,
+        },
+        "multipliers": {
+            "defense": 0.8,
+            "damage": 1.15,
+        },
+        "keywords": ["light", "fragile"],
+    }

--- a/scripts/abilities/w_blast.gd
+++ b/scripts/abilities/w_blast.gd
@@ -1,0 +1,31 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+@export var recoil_penalty: float = 0.15
+
+func _init() -> void:
+    ability_name = "W Blast"
+    cooldown = 10.0
+    activation_duration = 2.5
+    description = "Charge up a weak-force burst that hits hard but knocks stability out of balance." \
+        + " Self-inflicts a brief defence penalty."
+    activation_profile = {
+        "bonuses": {
+            "damage": 0.8,
+        },
+        "multipliers": {
+            "speed": 1.1,
+        },
+        "keywords": ["weak_force", "volatile"],
+    }
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    var info := super.activate(player, context)
+    if info.get("success", false):
+        player.apply_temporary_profile(self, {
+            "multipliers": {
+                "defense": 1.0 - recoil_penalty,
+            },
+        }, activation_duration + 1.5)
+        info["recoil_penalty"] = recoil_penalty
+        info["log"] = "W Blast detonates – recoil reduces defence by %d%%." % int(recoil_penalty * 100.0)
+    return info

--- a/scripts/abilities/weak_charge_field.gd
+++ b/scripts/abilities/weak_charge_field.gd
@@ -1,0 +1,15 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Weak Charge Field"
+    description = "Stabilise the W boson's massive charge, boosting damage but lowering long-term stability." \
+        + " Keeps the class aggressive."
+    persistent_profile = {
+        "bonuses": {
+            "damage": 0.25,
+        },
+        "multipliers": {
+            "defense": 0.95,
+        },
+        "keywords": ["weak_force", "aggressive"],
+    }

--- a/scripts/abilities/weak_flux.gd
+++ b/scripts/abilities/weak_flux.gd
@@ -1,0 +1,28 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+func _init() -> void:
+    ability_name = "Weak Flux"
+    cooldown = 14.0
+    activation_duration = 5.0
+    description = "Focus the weak force into a silent detonation – spreads debuffs while keeping stealth." \
+        + " Damage output dips after the pulse."
+    activation_profile = {
+        "bonuses": {
+            "stealth": 0.5,
+        },
+        "multipliers": {
+            "damage": 1.2,
+        },
+        "keywords": ["stealth", "weak_force"],
+    }
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    var details := super.activate(player, context)
+    if details.get("success", false):
+        player.apply_temporary_profile(self, {
+            "multipliers": {
+                "damage": 0.75,
+            },
+        }, activation_duration + 1.0)
+        details["log"] = "Weak Flux ripples outward – energy drain follows the pulse."
+    return details

--- a/scripts/abilities/z_pulse.gd
+++ b/scripts/abilities/z_pulse.gd
@@ -1,0 +1,33 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+@export var recoil_damage: float = 0.3
+
+func _init() -> void:
+    ability_name = "Z Pulse"
+    cooldown = 9.5
+    activation_duration = 2.0
+    description = "Neutral weak-force beam that pierces defences but knocks stability into the red." \
+        + " Balanced damage and recoil."
+    activation_profile = {
+        "bonuses": {
+            "damage": 0.7,
+        },
+        "multipliers": {
+            "defense": 1.05,
+        },
+        "keywords": ["weak_force", "neutral"],
+    }
+
+func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    var details := super.activate(player, context)
+    if details.get("success", false):
+        player.apply_temporary_profile(self, {
+            "bonuses": {
+                "shield": -50.0 * recoil_damage,
+            },
+            "multipliers": {
+                "defense": 1.0 - recoil_damage * 0.5,
+            },
+        }, activation_duration + 1.0)
+        details["log"] = "Z Pulse fires – neutral recoil saps %d%% defence." % int(recoil_damage * 50.0)
+    return details

--- a/scripts/classes/particle_class.gd
+++ b/scripts/classes/particle_class.gd
@@ -1,0 +1,37 @@
+extends Resource
+class_name ParticleClassDefinition
+
+## Defines a playable particle archetype with physics-flavoured stats
+## and hooks to the abilities that drive its behaviour.
+@export var id: StringName = &""
+@export var display_name: String = ""
+@export_multiline var description: String = ""
+
+## Core physical properties highlighted for flavour/gameplay.
+@export var mass: float = 1.0
+@export var charge: float = 0.0
+@export var stability: float = 1.0
+
+## Ability slots. The exported scripts must extend ParticleAbility.
+@export var active_ability: Script
+@export var passive_ability: Script
+@export var ultimate_ability: Script
+
+func _instantiate_ability(script: Script) -> ParticleAbility:
+    if script == null:
+        return null
+    var ability := script.new()
+    if ability is ParticleAbility:
+        return ability
+    push_warning("%s does not extend ParticleAbility" % script.resource_path)
+    return null
+
+func create_loadout() -> Dictionary:
+    return {
+        "active": _instantiate_ability(active_ability),
+        "passive": _instantiate_ability(passive_ability),
+        "ultimate": _instantiate_ability(ultimate_ability),
+    }
+
+func get_summary() -> String:
+    return "%s (q=%0.2f, m=%0.3f, stability=%0.2f)" % [display_name, charge, mass, stability]

--- a/scripts/player/player_avatar.gd
+++ b/scripts/player/player_avatar.gd
@@ -1,0 +1,168 @@
+extends CharacterBody2D
+class_name PlayerAvatar
+
+signal class_changed(new_class)
+signal ability_triggered(slot_name, ability: ParticleAbility, details: Dictionary)
+
+@export var base_stats := {
+    "speed": 220.0,
+    "damage": 1.0,
+    "defense": 1.0,
+    "shield": 0.0,
+    "stealth": 0.0,
+    "evasion": 0.0,
+    "control": 1.0,
+}
+@export var base_keywords: Array[StringName] = []
+
+@export var particle_class: ParticleClassDefinition = null setget set_particle_class
+var current_stats: Dictionary = {}
+var current_keywords: Array[StringName] = []
+var mass: float = 1.0
+var charge: float = 0.0
+var stability: float = 1.0
+
+var _abilities := {}
+var _profiles := {}
+var _profile_sources := {}
+var _profile_uid := 0
+
+func _ready() -> void:
+    _recalculate_stats()
+    if particle_class:
+        var initial := particle_class
+        particle_class = null
+        set_particle_class(initial)
+
+func set_particle_class(value: ParticleClassDefinition) -> void:
+    if value == particle_class:
+        return
+    _clear_abilities()
+    particle_class = value
+    if particle_class:
+        mass = particle_class.mass
+        charge = particle_class.charge
+        stability = particle_class.stability
+        var loadout := particle_class.create_loadout()
+        for slot in loadout:
+            _set_ability(slot, loadout[slot])
+    else:
+        mass = 1.0
+        charge = 0.0
+        stability = 1.0
+    emit_signal("class_changed", particle_class)
+
+func _set_ability(slot: StringName, ability: ParticleAbility) -> void:
+    if _abilities.has(slot) and _abilities[slot]:
+        var old: ParticleAbility = _abilities[slot]
+        old.on_unequip(self)
+    _abilities[slot] = ability
+    if ability:
+        ability.slot = slot
+        ability.on_equip(self)
+
+func _clear_abilities() -> void:
+    for slot in _abilities:
+        var ability: ParticleAbility = _abilities[slot]
+        if ability:
+            ability.on_unequip(self)
+    _abilities.clear()
+    remove_stat_profile(null)
+
+func use_ability(slot: StringName, context: Dictionary = {}) -> Dictionary:
+    if not _abilities.has(slot):
+        return {}
+    var ability: ParticleAbility = _abilities[slot]
+    if ability == null:
+        return {}
+    var details := ability.activate(self, context)
+    emit_signal("ability_triggered", slot, ability, details)
+    return details
+
+func use_active(context: Dictionary = {}) -> Dictionary:
+    return use_ability(&"active", context)
+
+func use_passive_refresh(context: Dictionary = {}) -> Dictionary:
+    return use_ability(&"passive", context)
+
+func use_ultimate(context: Dictionary = {}) -> Dictionary:
+    return use_ability(&"ultimate", context)
+
+func apply_stat_profile(source, profile: Dictionary) -> void:
+    var key := _profile_key(source)
+    _profiles[key] = _normalize_profile(profile)
+    _profile_sources[key] = source
+    _recalculate_stats()
+
+func apply_temporary_profile(source, profile: Dictionary, duration: float) -> void:
+    _profile_uid += 1
+    var key := _profile_key(source, "_temp_%d" % _profile_uid)
+    _profiles[key] = _normalize_profile(profile)
+    _profile_sources[key] = source
+    _recalculate_stats()
+    var timer := Timer.new()
+    timer.one_shot = true
+    timer.wait_time = max(duration, 0.0)
+    add_child(timer)
+    timer.timeout.connect(_on_temporary_profile_timeout.bind(key, timer))
+    timer.start()
+
+func _on_temporary_profile_timeout(key: StringName, timer: Timer) -> void:
+    _remove_profile_by_key(key)
+    timer.queue_free()
+
+func remove_stat_profile(source) -> void:
+    var removal_keys: Array[StringName] = []
+    for key in _profile_sources.keys():
+        if source == null or _profile_sources[key] == source:
+            removal_keys.append(key)
+    for key in removal_keys:
+        _remove_profile_by_key(key)
+
+func _remove_profile_by_key(key: StringName) -> void:
+    _profiles.erase(key)
+    _profile_sources.erase(key)
+    _recalculate_stats()
+
+func _profile_key(source, suffix: String = "") -> StringName:
+    if source == null:
+        return StringName("global%s" % suffix)
+    return StringName("%s%s" % [str(source.get_instance_id()), suffix])
+
+func _normalize_profile(profile: Dictionary) -> Dictionary:
+    var result := {
+        "bonuses": {},
+        "multipliers": {},
+        "keywords": [],
+    }
+    for key in profile.keys():
+        if result.has(key):
+            var value = profile[key]
+            if value is Dictionary:
+                result[key] = value.duplicate(true)
+            elif value is Array:
+                result[key] = value.duplicate()
+            else:
+                result[key] = value
+    return result
+
+func _recalculate_stats() -> void:
+    current_stats = base_stats.duplicate(true)
+    current_keywords = base_keywords.duplicate()
+    for profile in _profiles.values():
+        var bonuses: Dictionary = profile.get("bonuses", {})
+        for stat in bonuses.keys():
+            current_stats[stat] = current_stats.get(stat, 0.0) + bonuses[stat]
+        var multipliers: Dictionary = profile.get("multipliers", {})
+        for stat in multipliers.keys():
+            current_stats[stat] = current_stats.get(stat, 0.0) * multipliers[stat]
+        var keywords: Array = profile.get("keywords", [])
+        for keyword in keywords:
+            if keyword not in current_keywords:
+                current_keywords.append(keyword)
+
+func get_stat(stat: StringName) -> float:
+    return current_stats.get(stat, 0.0)
+
+func has_keyword(keyword: StringName) -> bool:
+    return keyword in current_keywords


### PR DESCRIPTION
## Summary
- add a ParticleClassDefinition resource that exposes mass/charge/stability stats and scripted ability slots
- implement a PlayerAvatar scene/controller that equips particle classes and applies ability stat profiles
- script abilities and class resources for quarks, leptons, gauge bosons, and the Higgs boson using the design document cues

## Testing
- Not run (Godot tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1a1f3ff68832989656a67ead5ac7b