### PR TITLE
Add reusable hazard scenes and prototype levels

### DIFF
--- a/scenes/hazards/chemical_vat.tscn
+++ b/scenes/hazards/chemical_vat.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/hazards/chemical_vat.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+extents = Vector2(140, 120)
+
+[node name="ChemicalVat" type="Area2D"]
+script = ExtResource("1")
+immune_class_ids = [&"noble_gas"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")

--- a/scenes/hazards/electric_field.tscn
+++ b/scenes/hazards/electric_field.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/hazards/electromagnetic_field.gd" id="1"]
+
+[sub_resource type="CircleShape2D" id="1"]
+radius = 120.0
+
+[node name="ElectricField" type="Area2D"]
+script = ExtResource("1")
+field_strength = 200.0
+immune_class_ids = [&"photon"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")

--- a/scenes/hazards/magnetic_trap.tscn
+++ b/scenes/hazards/magnetic_trap.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/hazards/magnetic_trap.gd" id="1"]
+
+[sub_resource type="RectangleShape2D" id="1"]
+extents = Vector2(160, 160)
+
+[node name="MagneticTrap" type="Area2D"]
+script = ExtResource("1")
+trap_strength = 260.0
+immune_class_ids = [&"gluon"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")

--- a/scenes/hazards/radiation_zone.tscn
+++ b/scenes/hazards/radiation_zone.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/hazards/radiation_zone.gd" id="1"]
+
+[sub_resource type="CircleShape2D" id="1"]
+radius = 180.0
+
+[node name="RadiationZone" type="Area2D"]
+script = ExtResource("1")
+intensity = 1.0
+immune_class_ids = [&"electron_neutrino"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")

--- a/scenes/levels/chemical_vat_prototype.tscn
+++ b/scenes/levels/chemical_vat_prototype.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/hazards/chemical_vat.tscn" id="2"]
+
+[node name="ChemicalVatPrototype" type="Node2D"]
+
+[node name="ExplosiveCrafter" parent="." instance=ExtResource("1")]
+position = Vector2(-200, -220)
+base_keywords = [&"explosive"]
+
+[node name="CorrosiveCrafter" parent="." instance=ExtResource("1")]
+position = Vector2(200, -220)
+base_keywords = [&"corrosive"]
+
+[node name="ChemicalVat" parent="." instance=ExtResource("2")]
+position = Vector2(0, 0)

--- a/scenes/levels/electric_field_prototype.tscn
+++ b/scenes/levels/electric_field_prototype.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/hazards/electric_field.tscn" id="2"]
+
+[node name="ElectricFieldPrototype" type="Node2D"]
+
+[node name="Player" parent="." instance=ExtResource("1")]
+position = Vector2(0, -220)
+
+[node name="ElectricField" parent="." instance=ExtResource("2")]
+position = Vector2(0, 0)

--- a/scenes/levels/magnetic_trap_prototype.tscn
+++ b/scenes/levels/magnetic_trap_prototype.tscn
@@ -1,0 +1,20 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/hazards/magnetic_trap.tscn" id="2"]
+[ext_resource type="Resource" path="res://data/classes/particles/down_quark.tres" id="3"]
+
+[node name="MagneticTrapPrototype" type="Node2D"]
+
+[node name="UpQuark" parent="." instance=ExtResource("1")]
+position = Vector2(-200, -160)
+
+[node name="UpQuark2" parent="." instance=ExtResource("1")]
+position = Vector2(0, -220)
+
+[node name="DownQuark" parent="." instance=ExtResource("1")]
+position = Vector2(200, -160)
+particle_class = ExtResource("3")
+
+[node name="MagneticTrap" parent="." instance=ExtResource("2")]
+position = Vector2(0, 0)

--- a/scenes/levels/radiation_zone_prototype.tscn
+++ b/scenes/levels/radiation_zone_prototype.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/hazards/radiation_zone.tscn" id="2"]
+[ext_resource type="Resource" path="res://data/classes/particles/electron_neutrino.tres" id="3"]
+
+[node name="RadiationZonePrototype" type="Node2D"]
+
+[node name="Electron" parent="." instance=ExtResource("1")]
+position = Vector2(-220, -200)
+
+[node name="Neutrino" parent="." instance=ExtResource("1")]
+position = Vector2(220, -200)
+particle_class = ExtResource("3")
+
+[node name="RadiationZone" parent="." instance=ExtResource("2")]
+position = Vector2(0, 0)

--- a/scripts/hazards/chemical_vat.gd
+++ b/scripts/hazards/chemical_vat.gd
@@ -1,0 +1,87 @@
+extends Area2D
+class_name ChemicalVat
+
+signal class_immunity_detected(player: PlayerAvatar)
+signal molecule_crafted(player: PlayerAvatar, molecule_id: StringName)
+signal bonus_granted(player: PlayerAvatar, bonus_id: StringName)
+
+@export var immune_class_ids: Array[StringName] = []
+@export var crafting_recipes: Dictionary = {
+    "explosive": {
+        "molecule": "volatile_solution",
+        "profile": {
+            "bonuses": {"damage": 0.35},
+            "multipliers": {"defense": 0.9},
+            "keywords": [StringName("volatile")],
+        },
+        "duration": 5.0,
+    },
+    "corrosive": {
+        "molecule": "acidic_slurry",
+        "profile": {
+            "bonuses": {"control": 0.2},
+            "multipliers": {},
+            "keywords": [StringName("acidic")],
+        },
+        "duration": 4.0,
+    },
+}
+@export var default_duration: float = 3.0
+
+var _active_players: Dictionary = {}
+
+func _ready() -> void:
+    body_entered.connect(_on_body_entered)
+    body_exited.connect(_on_body_exited)
+
+func _on_body_entered(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    if _is_class_immune(player):
+        emit_signal("class_immunity_detected", player)
+        return
+    var recipe := _get_recipe_for_player(player)
+    if recipe.is_empty():
+        return
+    var profile := recipe.get("profile", {})
+    var duration := float(recipe.get("duration", default_duration))
+    player.apply_temporary_profile(self, _duplicate_profile(profile), duration)
+    var molecule_id := StringName(recipe.get("molecule", "unknown_compound"))
+    _active_players[player] = molecule_id
+    emit_signal("molecule_crafted", player, molecule_id)
+    emit_signal("bonus_granted", player, StringName("alchemy_bonus"))
+
+func _on_body_exited(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    _active_players.erase(player)
+
+func _is_class_immune(player: PlayerAvatar) -> bool:
+    if player.particle_class == null:
+        return false
+    return StringName(player.particle_class.id) in immune_class_ids
+
+func _get_recipe_for_player(player: PlayerAvatar) -> Dictionary:
+    for key in crafting_recipes.keys():
+        var keyword := StringName(key)
+        if player.has_keyword(keyword):
+            var recipe = crafting_recipes[key]
+            if recipe is Dictionary:
+                return recipe
+    return {}
+
+func _duplicate_profile(profile: Dictionary) -> Dictionary:
+    var result := {
+        "bonuses": {},
+        "multipliers": {},
+        "keywords": [],
+    }
+    if profile.has("bonuses"):
+        result["bonuses"] = profile["bonuses"].duplicate(true)
+    if profile.has("multipliers"):
+        result["multipliers"] = profile["multipliers"].duplicate(true)
+    if profile.has("keywords"):
+        result["keywords"] = profile["keywords"].duplicate()
+    return result

--- a/scripts/hazards/electromagnetic_field.gd
+++ b/scripts/hazards/electromagnetic_field.gd
@@ -1,0 +1,91 @@
+extends Area2D
+class_name ElectromagneticField
+
+signal class_immunity_detected(player: PlayerAvatar)
+signal bonus_granted(player: PlayerAvatar, bonus_id: StringName)
+
+@export var field_strength: float = 180.0
+@export var repel_positive: bool = true
+@export var immune_class_ids: Array[StringName] = []
+@export var bonus_keywords: Array[StringName] = [StringName("charged")]
+@export var bonus_profile: Dictionary = {
+    "bonuses": {
+        "speed": 60.0,
+    },
+    "multipliers": {},
+    "keywords": [StringName("energized")],
+}
+
+var _tracked_players: Array[PlayerAvatar] = []
+var _players_with_bonus: Dictionary = {}
+
+func _ready() -> void:
+    body_entered.connect(_on_body_entered)
+    body_exited.connect(_on_body_exited)
+
+func _physics_process(delta: float) -> void:
+    for player in _tracked_players.duplicate():
+        if not is_instance_valid(player):
+            _tracked_players.erase(player)
+            _players_with_bonus.erase(player)
+            continue
+        var to_center := global_position - player.global_position
+        var distance := to_center.length()
+        if distance < 1.0:
+            continue
+        var direction := to_center / distance
+        var charge_value := player.charge
+        if abs(charge_value) <= 0.001:
+            continue
+        var attract := charge_value < 0.0 if repel_positive else charge_value > 0.0
+        var force_direction := direction if attract else -direction
+        player.velocity += force_direction * field_strength * abs(charge_value) * delta
+
+func _on_body_entered(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    if _is_class_immune(player):
+        emit_signal("class_immunity_detected", player)
+        return
+    if player not in _tracked_players:
+        _tracked_players.append(player)
+    if _should_grant_bonus(player) and not _players_with_bonus.get(player, false):
+        player.apply_stat_profile(self, _duplicate_profile(bonus_profile))
+        _players_with_bonus[player] = true
+        emit_signal("bonus_granted", player, StringName("charge_alignment"))
+
+func _on_body_exited(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    _tracked_players.erase(player)
+    if _players_with_bonus.get(player, false):
+        player.remove_stat_profile(self)
+        _players_with_bonus.erase(player)
+
+func _is_class_immune(player: PlayerAvatar) -> bool:
+    if player.particle_class == null:
+        return false
+    var id := StringName(player.particle_class.id)
+    return id in immune_class_ids
+
+func _should_grant_bonus(player: PlayerAvatar) -> bool:
+    for keyword in bonus_keywords:
+        if player.has_keyword(keyword):
+            return true
+    return false
+
+func _duplicate_profile(profile: Dictionary) -> Dictionary:
+    var result := {
+        "bonuses": {},
+        "multipliers": {},
+        "keywords": [],
+    }
+    if profile.has("bonuses"):
+        result["bonuses"] = profile["bonuses"].duplicate(true)
+    if profile.has("multipliers"):
+        result["multipliers"] = profile["multipliers"].duplicate(true)
+    if profile.has("keywords"):
+        result["keywords"] = profile["keywords"].duplicate()
+    return result

--- a/scripts/hazards/magnetic_trap.gd
+++ b/scripts/hazards/magnetic_trap.gd
@@ -1,0 +1,103 @@
+extends Area2D
+class_name MagneticTrap
+
+signal class_immunity_detected(player: PlayerAvatar)
+signal hadron_combined(players: Array)
+signal bonus_granted(player: PlayerAvatar, bonus_id: StringName)
+
+@export var trap_strength: float = 220.0
+@export var immune_class_ids: Array[StringName] = []
+@export var baryon_recipe: Array[StringName] = [StringName("up_quark"), StringName("up_quark"), StringName("down_quark")]
+@export var hadron_bonus_profile: Dictionary = {
+    "bonuses": {
+        "damage": 0.5,
+    },
+    "multipliers": {
+        "defense": 1.2,
+    },
+    "keywords": [StringName("hadronized")],
+}
+@export var hadron_bonus_duration: float = 4.0
+
+var _tracked_players: Array[PlayerAvatar] = []
+var _hadronized_players: Array[PlayerAvatar] = []
+
+func _ready() -> void:
+    body_entered.connect(_on_body_entered)
+    body_exited.connect(_on_body_exited)
+
+func _physics_process(delta: float) -> void:
+    for player in _tracked_players.duplicate():
+        if not is_instance_valid(player):
+            _tracked_players.erase(player)
+            continue
+        var to_center := global_position - player.global_position
+        var distance := max(to_center.length(), 1.0)
+        var pull := to_center.normalized() * trap_strength * delta
+        var tangential := Vector2(-to_center.y, to_center.x).normalized() * trap_strength * 0.5 * delta
+        player.velocity += pull + tangential / max(distance / 64.0, 1.0)
+    _try_hadronize()
+
+func _on_body_entered(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    if _is_class_immune(player):
+        emit_signal("class_immunity_detected", player)
+        return
+    if player not in _tracked_players:
+        _tracked_players.append(player)
+
+func _on_body_exited(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    _tracked_players.erase(player)
+    _hadronized_players.erase(player)
+
+func _try_hadronize() -> void:
+    if baryon_recipe.is_empty():
+        return
+    var counts := {}
+    for class_id in baryon_recipe:
+        counts[class_id] = counts.get(class_id, 0) + 1
+    var matches: Array[PlayerAvatar] = []
+    var temp_counts := counts.duplicate(true)
+    for player in _tracked_players:
+        if not is_instance_valid(player):
+            continue
+        if player.particle_class == null:
+            continue
+        var id := StringName(player.particle_class.id)
+        if temp_counts.get(id, 0) > 0 and player not in _hadronized_players:
+            matches.append(player)
+            temp_counts[id] -= 1
+    for remaining in temp_counts.values():
+        if remaining > 0:
+            return
+    if matches.size() != baryon_recipe.size():
+        return
+    for player in matches:
+        player.apply_temporary_profile(self, _duplicate_profile(hadron_bonus_profile), hadron_bonus_duration)
+        _hadronized_players.append(player)
+        emit_signal("bonus_granted", player, StringName("hadron_bonus"))
+    emit_signal("hadron_combined", matches.duplicate())
+
+func _is_class_immune(player: PlayerAvatar) -> bool:
+    if player.particle_class == null:
+        return false
+    return StringName(player.particle_class.id) in immune_class_ids
+
+func _duplicate_profile(profile: Dictionary) -> Dictionary:
+    var result := {
+        "bonuses": {},
+        "multipliers": {},
+        "keywords": [],
+    }
+    if profile.has("bonuses"):
+        result["bonuses"] = profile["bonuses"].duplicate(true)
+    if profile.has("multipliers"):
+        result["multipliers"] = profile["multipliers"].duplicate(true)
+    if profile.has("keywords"):
+        result["keywords"] = profile["keywords"].duplicate()
+    return result

--- a/scripts/hazards/radiation_zone.gd
+++ b/scripts/hazards/radiation_zone.gd
@@ -1,0 +1,89 @@
+extends Area2D
+class_name RadiationZone
+
+signal class_immunity_detected(player: PlayerAvatar)
+signal radiation_tick(player: PlayerAvatar, intensity: float)
+signal radiation_resisted(player: PlayerAvatar)
+
+@export var intensity: float = 0.75
+@export var tick_interval: float = 1.0
+@export var immune_class_ids: Array[StringName] = []
+@export var resistant_keywords: Array[StringName] = [StringName("stable")]
+@export var radiation_profile: Dictionary = {
+    "bonuses": {},
+    "multipliers": {
+        "defense": 0.9,
+    },
+    "keywords": [StringName("irradiated")],
+}
+@export var profile_duration: float = 1.2
+
+var _exposed_players: Dictionary = {}
+
+func _ready() -> void:
+    body_entered.connect(_on_body_entered)
+    body_exited.connect(_on_body_exited)
+
+func _physics_process(delta: float) -> void:
+    for player in _exposed_players.keys().duplicate():
+        var data: Dictionary = _exposed_players.get(player)
+        if data == null:
+            _exposed_players.erase(player)
+            continue
+        if not is_instance_valid(player):
+            _exposed_players.erase(player)
+            continue
+        data["timer"] += delta
+        if data["timer"] >= tick_interval:
+            data["timer"] -= tick_interval
+            _apply_radiation(player)
+
+func _on_body_entered(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    if _is_class_immune(player):
+        emit_signal("class_immunity_detected", player)
+        return
+    if _is_resistant(player):
+        emit_signal("radiation_resisted", player)
+        return
+    _exposed_players[player] = {"timer": 0.0}
+    _apply_radiation(player)
+
+func _on_body_exited(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    _exposed_players.erase(player)
+
+func _apply_radiation(player: PlayerAvatar) -> void:
+    if not is_instance_valid(player):
+        return
+    player.apply_temporary_profile(self, _duplicate_profile(radiation_profile), profile_duration)
+    emit_signal("radiation_tick", player, intensity)
+
+func _is_class_immune(player: PlayerAvatar) -> bool:
+    if player.particle_class == null:
+        return false
+    return StringName(player.particle_class.id) in immune_class_ids
+
+func _is_resistant(player: PlayerAvatar) -> bool:
+    for keyword in resistant_keywords:
+        if player.has_keyword(keyword):
+            return true
+    return false
+
+func _duplicate_profile(profile: Dictionary) -> Dictionary:
+    var result := {
+        "bonuses": {},
+        "multipliers": {},
+        "keywords": [],
+    }
+    if profile.has("bonuses"):
+        result["bonuses"] = profile["bonuses"].duplicate(true)
+    if profile.has("multipliers"):
+        result["multipliers"] = profile["multipliers"].duplicate(true)
+    if profile.has("keywords"):
+        result["keywords"] = profile["keywords"].duplicate()
+    return result


### PR DESCRIPTION
## Summary
- create reusable Area2D hazards for electric fields, magnetic traps, radiation zones, and chemical vats with immunity/bonus signals
- implement hazard behaviours that react to particle charge, class ids, and keywords for quark fusion and elemental crafting
- add prototype levels that place sample player avatars with each hazard to validate counterplay setups

## Testing
- not run (Godot content only)


------
https://chatgpt.com/codex/tasks/task_e_68e1a5dc99d88329be92e30d4403b9e5