### PR TITLE
Add reusable ability base and status management

### DIFF
--- a/scripts/abilities/ability.gd
+++ b/scripts/abilities/ability.gd
@@ -1,0 +1,182 @@
+extends Resource
+class_name Ability
+
+## Base ability resource that handles activation cooldowns, resource costs,
+## and animation hooks. Concrete abilities should inherit from this class
+## and override [_execute_activation] to provide their gameplay effect.
+
+signal cooldown_started(duration: float)
+signal cooldown_completed()
+
+@export var ability_name: String = ""
+@export_multiline var description: String = ""
+@export var cooldown: float = 0.0
+@export var resource_costs: Dictionary = {}
+@export var animation_state: StringName = &""
+@export var animation_speed: float = 1.0
+@export var animation_blend_time: float = 0.1
+
+var slot: StringName = &""
+var _cooldown_ready_time: float = 0.0
+
+func on_equip(_user) -> void:
+    pass
+
+func on_unequip(_user) -> void:
+    pass
+
+func can_activate(user, context: Dictionary = {}) -> Dictionary:
+    if is_on_cooldown():
+        var remaining := get_cooldown_remaining()
+        return {
+            "allowed": false,
+            "log": "%s is recharging (%0.2fs remaining)." % [ability_name, remaining],
+            "cooldown_remaining": remaining,
+        }
+    var cost_check := _can_pay_cost(user)
+    if not cost_check.get("ok", true):
+        var missing: Dictionary = cost_check.get("missing", {})
+        var log := cost_check.get("log", "")
+        if log == "" and not missing.is_empty():
+            log = "%s requires %s." % [ability_name, _format_cost_summary(missing)]
+        elif log == "":
+            log = "%s cannot be activated." % ability_name
+        return {
+            "allowed": false,
+            "log": log,
+            "missing_costs": missing,
+        }
+    return {"allowed": true}
+
+func activate(user, context: Dictionary = {}) -> Dictionary:
+    var validation := can_activate(user, context)
+    if not validation.get("allowed", true):
+        validation["success"] = false
+        return validation
+    if not _apply_costs(user):
+        return {
+            "success": false,
+            "log": "%s could not pay the activation cost." % ability_name,
+        }
+    var result := _execute_activation(user, context)
+    if result == null:
+        result = {}
+    var success := bool(result.get("success", true))
+    result["success"] = success
+    if success:
+        _start_cooldown()
+        _inject_animation_hook(result)
+    result["cooldown_remaining"] = get_cooldown_remaining()
+    if not result.has("log") or String(result["log"]).is_empty():
+        result["log"] = "%s activated." % ability_name if success else "%s fizzles." % ability_name
+    return result
+
+func get_cooldown_remaining(now: float = -1.0) -> float:
+    if now < 0.0:
+        now = _now()
+    return max(_cooldown_ready_time - now, 0.0)
+
+func is_on_cooldown() -> bool:
+    return get_cooldown_remaining() > 0.0
+
+func reset_cooldown() -> void:
+    _cooldown_ready_time = _now()
+    emit_signal("cooldown_completed")
+
+func start_cooldown(duration: float) -> void:
+    _start_cooldown(duration)
+
+func get_animation_request() -> Dictionary:
+    if animation_state == &"":
+        return {}
+    var request := {
+        "state": animation_state,
+        "speed": animation_speed,
+    }
+    if animation_blend_time > 0.0:
+        request["blend_time"] = animation_blend_time
+    return request
+
+func _execute_activation(_user, _context: Dictionary) -> Dictionary:
+    return {"success": true}
+
+func _now() -> float:
+    return float(Time.get_ticks_msec()) / 1000.0
+
+func _start_cooldown(duration: float = -1.0) -> void:
+    var cd := cooldown if duration < 0.0 else max(duration, 0.0)
+    if cd <= 0.0:
+        _cooldown_ready_time = _now()
+        emit_signal("cooldown_completed")
+        return
+    _cooldown_ready_time = _now() + cd
+    emit_signal("cooldown_started", cd)
+
+func _inject_animation_hook(result: Dictionary) -> void:
+    var request := get_animation_request()
+    if request.is_empty():
+        return
+    result["animation_request"] = request
+
+func _apply_costs(user) -> bool:
+    if resource_costs.is_empty():
+        return true
+    if user == null:
+        return false
+    if user.has_method("apply_resource_costs"):
+        return user.apply_resource_costs(resource_costs)
+    if user.has_method("modify_resource"):
+        for name in resource_costs.keys():
+            user.modify_resource(name, -float(resource_costs[name]))
+        return true
+    return false
+
+func _can_pay_cost(user) -> Dictionary:
+    if resource_costs.is_empty():
+        return {"ok": true}
+    if user == null:
+        return {
+            "ok": false,
+            "missing": resource_costs.duplicate(true),
+            "log": "%s requires %s." % [ability_name, _format_cost_summary(resource_costs)],
+        }
+    if user.has_method("has_resources"):
+        if user.has_resources(resource_costs):
+            return {"ok": true}
+        var missing := {}
+        if user.has_method("get_missing_resources"):
+            missing = user.get_missing_resources(resource_costs)
+        var summary := _format_cost_summary(missing)
+        return {
+            "ok": false,
+            "missing": missing,
+            "log": "%s requires %s." % [ability_name, summary],
+        }
+    if user.has_method("get_resource_amount"):
+        var missing_local := {}
+        for name in resource_costs.keys():
+            var required := float(resource_costs[name])
+            var available := float(user.get_resource_amount(name))
+            if available + 0.0001 < required:
+                missing_local[name] = required - available
+        if missing_local.is_empty():
+            return {"ok": true}
+        return {
+            "ok": false,
+            "missing": missing_local,
+            "log": "%s requires %s." % [ability_name, _format_cost_summary(missing_local)],
+        }
+    return {
+        "ok": false,
+        "missing": resource_costs.duplicate(true),
+        "log": "%s cannot verify resource requirements." % ability_name,
+    }
+
+func _format_cost_summary(costs: Dictionary) -> String:
+    if costs.is_empty():
+        return "no resources"
+    var parts: Array = []
+    for key in costs.keys():
+        var amount := float(costs[key])
+        parts.append("%s x%0.2f" % [str(key), amount])
+    return ", ".join(parts)

--- a/scripts/abilities/ability_catalog.gd
+++ b/scripts/abilities/ability_catalog.gd
@@ -1,0 +1,21 @@
+extends Node
+class_name AbilityCatalog
+
+const CATALOG: Dictionary = {
+    StringName("photon_dash"): preload("res://scripts/abilities/photon_dash.gd"),
+    StringName("gluon_bind"): preload("res://scripts/abilities/gluon_bind.gd"),
+    StringName("halogen_corrosion"): preload("res://scripts/abilities/halogen_corrosion.gd"),
+    StringName("noble_gas_barrier"): preload("res://scripts/abilities/noble_gas_barrier.gd"),
+}
+
+static func get_catalog() -> Dictionary:
+    return CATALOG.duplicate()
+
+static func has_ability(id: StringName) -> bool:
+    return CATALOG.has(id)
+
+static func create(id: StringName):
+    if not CATALOG.has(id):
+        return null
+    var script: Script = CATALOG[id]
+    return script.new()

--- a/scripts/abilities/gluon_bind.gd
+++ b/scripts/abilities/gluon_bind.gd
@@ -1,11 +1,14 @@
 extends "res://scripts/abilities/particle_ability.gd"
 
 @export var tether_strength: float = 0.8
+@export var tether_duration: float = 5.0
+@export var energy_cost: float = 35.0
 
 func _init() -> void:
     ability_name = "Gluon Bind"
     cooldown = 9.0
-    activation_duration = 5.0
+    activation_duration = tether_duration
+    resource_costs = {&"energy": energy_cost}
     description = "Project a strong-force tether that links allies or snares foes, boosting defence while active." \
         + " Enemies struggle to escape the colour flux."
     activation_profile = {
@@ -17,10 +20,28 @@ func _init() -> void:
         },
         "keywords": ["binding", "support"],
     }
+    animation_state = &"cast"
+    animation_speed = 0.9
 
-func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
-    var details := super.activate(player, context)
-    if details.get("success", false):
-        details["tether_strength"] = tether_strength
-        details["log"] = "Gluon Bind forms a colour flux tether (strength %0.2f)." % tether_strength
-    return details
+func _after_activation(player: PlayerAvatar, context: Dictionary, result: Dictionary) -> Dictionary:
+    var target = context.get("target")
+    if target == null:
+        return result
+    if target == player:
+        return result
+    if not target.has_method("get_status_manager"):
+        return result
+    var manager = target.get_status_manager()
+    if manager == null:
+        return result
+    var status_data := {
+        "tags": [StringName("strong_force"), StringName("binding")],
+        "tether_strength": tether_strength,
+    }
+    var applied := manager.apply_status(&"bound", tether_duration, status_data, player)
+    result["tether_status"] = applied
+    if applied.get("immune", false):
+        result["log"] += " Target resists the colour flux."
+    elif applied.get("success", false):
+        result["log"] += " Target is caught in the gluon weave (strength %0.2f)." % tether_strength
+    return result

--- a/scripts/abilities/halogen_corrosion.gd
+++ b/scripts/abilities/halogen_corrosion.gd
@@ -1,0 +1,61 @@
+extends "res://scripts/abilities/ability.gd"
+
+@export var corrosion_duration: float = 4.0
+@export var defense_penalty: float = -22.0
+@export var corrosion_damage_per_second: float = 6.0
+@export var energy_cost: float = 18.0
+
+func _init() -> void:
+    ability_name = "Halogen Corrosion"
+    cooldown = 7.0
+    resource_costs = {&"energy": energy_cost}
+    description = "Atomise a volatile halogen cloud that strips protective layers and scars unstable particles." \
+        + " Applies a corrosive status that gnaws at defence and punishes instability."
+    animation_state = &"cast"
+    animation_speed = 1.1
+
+func _execute_activation(user, context: Dictionary = {}) -> Dictionary:
+    var target = context.get("target")
+    if target == null:
+        return {
+            "success": false,
+            "log": "Halogen Corrosion requires a target.",
+        }
+    var duration := context.get("duration", corrosion_duration)
+    var log_message := "%s bathes the target in reactive ions." % ability_name
+    var profile_applied := false
+    if target.has_method("apply_temporary_profile"):
+        var profile := {
+            "bonuses": {"defense": defense_penalty},
+            "keywords": [StringName("corroded")],
+        }
+        target.apply_temporary_profile(self, profile, duration)
+        log_message += " Defensive plating is etched away."
+        profile_applied = true
+    var status_result := _apply_corrosion_status(target, duration, user)
+    if status_result.get("immune", false):
+        log_message += " Target structure is immune to corrosion."
+    elif status_result.get("success", false):
+        log_message += " Corrosion gnaws for %0.1fs." % duration
+    return {
+        "success": profile_applied or status_result.get("success", false),
+        "log": log_message,
+        "status": status_result,
+        "duration": duration,
+    }
+
+func _apply_corrosion_status(target, duration: float, source) -> Dictionary:
+    if not target.has_method("get_status_manager"):
+        return {"success": false}
+    var manager = target.get_status_manager()
+    if manager == null:
+        return {"success": false}
+    var status_data := {
+        "tags": [StringName("corrosion"), StringName("chemical")],
+        "self_damage": {
+            "per_second": corrosion_damage_per_second,
+            "scales_with_instability": true,
+            "type": StringName("etching"),
+        },
+    }
+    return manager.apply_status(&"corroded", duration, status_data, source)

--- a/scripts/abilities/noble_gas_barrier.gd
+++ b/scripts/abilities/noble_gas_barrier.gd
@@ -1,0 +1,49 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+@export var barrier_shield_bonus: float = 120.0
+@export var barrier_defense_multiplier: float = 1.4
+@export var barrier_duration: float = 6.0
+@export var energy_cost: float = 24.0
+
+func _init() -> void:
+    ability_name = "Noble Gas Barrier"
+    cooldown = 10.0
+    activation_duration = barrier_duration
+    resource_costs = {&"energy": energy_cost}
+    description = "Condense inert noble gases into a lattice that absorbs incoming energy and stabilises allies." \
+        + " Provides a sturdy barrier and grants damage resistance while it persists."
+    activation_profile = {
+        "bonuses": {
+            "shield": barrier_shield_bonus,
+        },
+        "multipliers": {
+            "defense": barrier_defense_multiplier,
+        },
+        "keywords": [StringName("barrier"), StringName("stable")],
+    }
+    activation_log_message = "Noble Gas Barrier crystallises into a radiant shell."
+    animation_state = &"shield"
+    animation_speed = 0.9
+
+func _after_activation(player: PlayerAvatar, context: Dictionary, result: Dictionary) -> Dictionary:
+    var target = context.get("target")
+    if target == null:
+        target = player
+    if not target.has_method("get_status_manager"):
+        return result
+    var manager = target.get_status_manager()
+    if manager == null:
+        return result
+    var status_data := {
+        "tags": [StringName("barrier"), StringName("shield")],
+        "absorption": barrier_shield_bonus,
+        "self_damage": {
+            "per_second": 0.0,
+            "scales_with_instability": false,
+        },
+    }
+    var applied := manager.apply_status(&"barrier", barrier_duration, status_data, player)
+    result["barrier_status"] = applied
+    if applied.get("success", false):
+        result["log"] += " Protective gases damp incoming force."
+    return result

--- a/scripts/abilities/particle_ability.gd
+++ b/scripts/abilities/particle_ability.gd
@@ -1,9 +1,6 @@
-extends Resource
+extends "res://scripts/abilities/ability.gd"
 class_name ParticleAbility
 
-@export var ability_name: String = ""
-@export_multiline var description: String = ""
-@export var cooldown: float = 0.0
 @export var activation_duration: float = 0.0
 @export var activation_profile: Dictionary = {}
 @export var activation_keywords: Array[StringName] = []
@@ -20,6 +17,9 @@ func on_unequip(player: PlayerAvatar) -> void:
     player.remove_stat_profile(self)
 
 func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
+    return super.activate(player, context)
+
+func _execute_activation(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
     if activation_profile.is_empty():
         return {
             "log": "%s is ready." % ability_name,
@@ -38,8 +38,12 @@ func activate(player: PlayerAvatar, context: Dictionary = {}) -> Dictionary:
     else:
         player.apply_stat_profile(self, profile)
     var message := activation_log_message if activation_log_message != "" else "%s activated." % ability_name
-    return {
+    var result := {
         "log": message,
         "success": true,
         "duration": duration,
     }
+    return _after_activation(player, context, result)
+
+func _after_activation(_player: PlayerAvatar, _context: Dictionary, result: Dictionary) -> Dictionary:
+    return result

--- a/scripts/abilities/photon_dash.gd
+++ b/scripts/abilities/photon_dash.gd
@@ -1,0 +1,27 @@
+extends "res://scripts/abilities/particle_ability.gd"
+
+@export var dash_speed_bonus: float = 260.0
+@export var dash_evasion_multiplier: float = 1.35
+@export var dash_control_multiplier: float = 0.65
+@export var energy_cost: float = 20.0
+
+func _init() -> void:
+    ability_name = "Photon Dash"
+    cooldown = 4.5
+    activation_duration = 1.4
+    resource_costs = {&"energy": energy_cost}
+    description = "Accelerate into a beamline sprint, slipping past hazards while destabilising control surfaces." \
+        + " Movement speed and evasion spike as the particle blurs through phase space."
+    activation_profile = {
+        "bonuses": {
+            "speed": dash_speed_bonus,
+        },
+        "multipliers": {
+            "evasion": dash_evasion_multiplier,
+            "control": dash_control_multiplier,
+        },
+        "keywords": [StringName("phased"), StringName("velocity")],
+    }
+    activation_log_message = "Photon Dash cascades into superluminal lanes."
+    animation_state = &"dash"
+    animation_speed = 1.6

--- a/scripts/combat/status_manager.gd
+++ b/scripts/combat/status_manager.gd
@@ -1,0 +1,155 @@
+extends Node
+class_name StatusManager
+
+signal status_applied(status_name: StringName, info: Dictionary)
+signal status_refreshed(status_name: StringName, info: Dictionary)
+signal status_removed(status_name: StringName, info: Dictionary)
+signal self_damage_triggered(payload: Dictionary)
+
+@export var host: Node = null
+@export var immunity_flags: Dictionary = {}
+@export var instability_factor: float = 0.0 setget set_instability_factor, get_instability_factor
+
+var _statuses: Dictionary = {}
+var _instability_factor: float = 0.0
+
+func _ready() -> void:
+    set_process(true)
+
+func _process(delta: float) -> void:
+    tick(delta)
+
+func set_instability_factor(value: float) -> void:
+    _instability_factor = max(value, 0.0)
+
+func get_instability_factor() -> float:
+    return _instability_factor
+
+func tick(delta: float) -> void:
+    if _statuses.is_empty():
+        return
+    var expired: Array[StringName] = []
+    for status_name in _statuses.keys():
+        var info: Dictionary = _statuses[status_name]
+        info["remaining"] = max(info.get("remaining", 0.0) - delta, 0.0)
+        _handle_self_damage(status_name, info, delta)
+        _statuses[status_name] = info
+        if info.get("remaining", 0.0) <= 0.0:
+            expired.append(status_name)
+    for status_name in expired:
+        var removed_info: Dictionary = _statuses[status_name]
+        _statuses.erase(status_name)
+        emit_signal("status_removed", status_name, removed_info.duplicate(true))
+
+func apply_status(status_name: StringName, duration: float, data: Dictionary = {}, source = null) -> Dictionary:
+    if duration <= 0.0:
+        return {"success": false, "reason": "invalid_duration"}
+    var status_data := data.duplicate(true)
+    if _is_immune(status_data):
+        return {
+            "success": false,
+            "immune": true,
+            "status": status_name,
+            "log": "%s is immune to %s." % [str(host), str(status_name)],
+        }
+    var info: Dictionary = _statuses.get(status_name, {})
+    if info.is_empty():
+        info = {
+            "name": status_name,
+            "duration": duration,
+            "remaining": duration,
+            "source": source,
+            "data": status_data,
+            "stacks": 1,
+        }
+        _statuses[status_name] = info
+        emit_signal("status_applied", status_name, info.duplicate(true))
+        return {
+            "success": true,
+            "applied": true,
+            "status": info.duplicate(true),
+        }
+    info["source"] = source
+    var refresh_mode := status_data.get("refresh_mode", "max")
+    if refresh_mode == "add":
+        info["remaining"] = info.get("remaining", duration) + duration
+    else:
+        info["remaining"] = max(info.get("remaining", duration), duration)
+    if status_data.get("stackable", false):
+        var max_stacks := int(status_data.get("max_stacks", 5))
+        info["stacks"] = clamp(info.get("stacks", 1) + 1, 1, max_stacks)
+    info["data"] = _merge_dict(info.get("data", {}), status_data)
+    _statuses[status_name] = info
+    emit_signal("status_refreshed", status_name, info.duplicate(true))
+    return {
+        "success": true,
+        "refreshed": true,
+        "status": info.duplicate(true),
+    }
+
+func remove_status(status_name: StringName) -> void:
+    if not _statuses.has(status_name):
+        return
+    var info: Dictionary = _statuses[status_name]
+    _statuses.erase(status_name)
+    emit_signal("status_removed", status_name, info.duplicate(true))
+
+func clear_all_statuses() -> void:
+    if _statuses.is_empty():
+        return
+    for status_name in _statuses.keys():
+        emit_signal("status_removed", status_name, _statuses[status_name].duplicate(true))
+    _statuses.clear()
+
+func has_status(status_name: StringName) -> bool:
+    return _statuses.has(status_name)
+
+func get_status(status_name: StringName) -> Dictionary:
+    var info: Dictionary = _statuses.get(status_name, {})
+    return info.duplicate(true) if not info.is_empty() else {}
+
+func set_immunity(tag: StringName, enabled: bool) -> void:
+    immunity_flags[tag] = enabled
+
+func clear_immunities() -> void:
+    immunity_flags.clear()
+
+func is_immune_to(tag: StringName) -> bool:
+    return bool(immunity_flags.get(tag, false))
+
+func _is_immune(data: Dictionary) -> bool:
+    var tags: Array = data.get("tags", [])
+    for tag in tags:
+        if is_immune_to(tag):
+            return true
+    return false
+
+func _handle_self_damage(status_name: StringName, info: Dictionary, delta: float) -> void:
+    var data: Dictionary = info.get("data", {})
+    var self_damage: Dictionary = data.get("self_damage", {})
+    if self_damage.is_empty():
+        return
+    var rate := float(self_damage.get("per_second", 0.0))
+    if rate <= 0.0:
+        return
+    var scale := 1.0
+    if self_damage.get("scales_with_instability", true):
+        scale += _instability_factor
+    var amount := rate * delta * scale
+    if amount <= 0.0:
+        return
+    var payload := {
+        "status": status_name,
+        "amount": amount,
+        "type": self_damage.get("type", StringName("")),
+        "source": info.get("source"),
+    }
+    emit_signal("self_damage_triggered", payload)
+    if host and host.has_method("apply_self_damage"):
+        host.apply_self_damage(payload)
+
+func _merge_dict(base: Dictionary, extra: Dictionary) -> Dictionary:
+    var result := base.duplicate(true)
+    for key in extra.keys():
+        result[key] = extra[key]
+    return result

--- a/scripts/player/player_avatar.gd
+++ b/scripts/player/player_avatar.gd
@@ -1,8 +1,16 @@
 extends CharacterBody2D
 class_name PlayerAvatar
 
+const StatusManager := preload("res://scripts/combat/status_manager.gd")
+const LEPTON_IDS := {
+    StringName("electron"): true,
+    StringName("electron_neutrino"): true,
+}
+
 signal class_changed(new_class)
 signal ability_triggered(slot_name, ability: ParticleAbility, details: Dictionary)
+signal resource_changed(resource_name: StringName, current: float, maximum: float)
+signal self_damage_taken(amount: float, payload: Dictionary)
 
 @export var base_stats := {
     "speed": 220.0,
@@ -22,19 +30,28 @@ var mass: float = 1.0
 var charge: float = 0.0
 var stability: float = 1.0
 
+var resource_pools: Dictionary = {}
+var status_manager: StatusManager = null
+
 var _abilities := {}
 var _profiles := {}
 var _profile_sources := {}
 var _profile_uid := 0
 
+func _enter_tree() -> void:
+    _ensure_status_manager()
+
 func _ready() -> void:
     _recalculate_stats()
+    _initialize_resources()
+    _update_instability_factor()
     if particle_class:
         var initial := particle_class
         particle_class = null
         set_particle_class(initial)
 
 func set_particle_class(value: ParticleClassDefinition) -> void:
+    _ensure_status_manager()
     if value == particle_class:
         return
     _clear_abilities()
@@ -43,6 +60,7 @@ func set_particle_class(value: ParticleClassDefinition) -> void:
         mass = particle_class.mass
         charge = particle_class.charge
         stability = particle_class.stability
+        _initialize_resources()
         var loadout := particle_class.create_loadout()
         for slot in loadout:
             _set_ability(slot, loadout[slot])
@@ -50,7 +68,89 @@ func set_particle_class(value: ParticleClassDefinition) -> void:
         mass = 1.0
         charge = 0.0
         stability = 1.0
+        _initialize_resources()
+    _update_instability_factor()
+    _update_status_immunities()
     emit_signal("class_changed", particle_class)
+
+func get_status_manager() -> StatusManager:
+    return status_manager
+
+func set_resource(name: StringName, current: float, maximum: float) -> void:
+    name = StringName(name)
+    maximum = max(maximum, 0.0)
+    var pool := {
+        "current": clamp(current, 0.0, maximum if maximum > 0.0 else current),
+        "max": maximum,
+    }
+    if maximum <= 0.0:
+        pool["current"] = max(current, 0.0)
+    resource_pools[name] = pool
+    emit_signal("resource_changed", name, pool["current"], pool["max"])
+    if name == &"stability":
+        _update_instability_factor()
+
+func modify_resource(name: StringName, delta: float) -> void:
+    name = StringName(name)
+    var pool: Dictionary = resource_pools.get(name, {})
+    var max_amount := float(pool.get("max", 0.0))
+    var current := float(pool.get("current", 0.0)) + delta
+    if max_amount > 0.0:
+        current = clamp(current, 0.0, max_amount)
+    else:
+        current = max(current, 0.0)
+        max_amount = max(max_amount, current)
+    pool["current"] = current
+    pool["max"] = max_amount
+    resource_pools[name] = pool
+    emit_signal("resource_changed", name, current, max_amount)
+    if name == &"stability":
+        _update_instability_factor()
+
+func get_resource_amount(name: StringName) -> float:
+    name = StringName(name)
+    var pool: Dictionary = resource_pools.get(name, {})
+    return float(pool.get("current", 0.0))
+
+func get_resource_capacity(name: StringName) -> float:
+    name = StringName(name)
+    var pool: Dictionary = resource_pools.get(name, {})
+    return float(pool.get("max", 0.0))
+
+func has_resources(costs: Dictionary) -> bool:
+    for name in costs.keys():
+        if get_resource_amount(StringName(name)) + 0.0001 < float(costs[name]):
+            return false
+    return true
+
+func get_missing_resources(costs: Dictionary) -> Dictionary:
+    var missing := {}
+    for name in costs.keys():
+        var required := float(costs[name])
+        var available := get_resource_amount(StringName(name))
+        if available + 0.0001 < required:
+            missing[name] = required - available
+    return missing
+
+func apply_resource_costs(costs: Dictionary) -> bool:
+    if not has_resources(costs):
+        return false
+    for name in costs.keys():
+        modify_resource(StringName(name), -float(costs[name]))
+    return true
+
+func restore_resource(name: StringName, amount: float) -> void:
+    name = StringName(name)
+    if amount <= 0.0:
+        return
+    modify_resource(name, amount)
+
+func apply_self_damage(payload: Dictionary) -> void:
+    var amount := float(payload.get("amount", 0.0))
+    if amount <= 0.0:
+        return
+    modify_resource(&"stability", -amount)
+    emit_signal("self_damage_taken", amount, payload)
 
 func _set_ability(slot: StringName, ability: ParticleAbility) -> void:
     if _abilities.has(slot) and _abilities[slot]:
@@ -68,6 +168,8 @@ func _clear_abilities() -> void:
             ability.on_unequip(self)
     _abilities.clear()
     remove_stat_profile(null)
+    if status_manager:
+        status_manager.clear_all_statuses()
 
 func use_ability(slot: StringName, context: Dictionary = {}) -> Dictionary:
     if not _abilities.has(slot):
@@ -166,3 +268,38 @@ func get_stat(stat: StringName) -> float:
 
 func has_keyword(keyword: StringName) -> bool:
     return keyword in current_keywords
+
+func _ensure_status_manager() -> void:
+    if status_manager:
+        return
+    status_manager = StatusManager.new()
+    status_manager.name = "StatusManager"
+    status_manager.host = self
+    add_child(status_manager)
+    _update_status_immunities()
+
+func _initialize_resources() -> void:
+    resource_pools.clear()
+    set_resource(&"energy", 100.0, 100.0)
+    var stability_capacity := max(stability, 0.0) * 100.0
+    if stability_capacity <= 0.0:
+        stability_capacity = 1.0
+    set_resource(&"stability", stability_capacity, stability_capacity)
+
+func _update_instability_factor() -> void:
+    if status_manager == null:
+        return
+    var baseline := clamp(1.0 - stability, 0.0, 1.0)
+    var stability_pool: Dictionary = resource_pools.get(&"stability", {})
+    var max_amount := float(stability_pool.get("max", 0.0))
+    if max_amount > 0.0:
+        var ratio := float(stability_pool.get("current", max_amount)) / max_amount
+        baseline = max(baseline, 1.0 - ratio)
+    status_manager.set_instability_factor(baseline)
+
+func _update_status_immunities() -> void:
+    if status_manager == null:
+        return
+    status_manager.clear_immunities()
+    if particle_class and LEPTON_IDS.has(particle_class.id):
+        status_manager.set_immunity(&"strong_force", true)


### PR DESCRIPTION
## Summary
- add a reusable Ability base class that manages cooldowns, resource costs, and animation hooks and update ParticleAbility to build on it
- implement Photon Dash, Gluon Bind, Halogen Corrosion, and Noble Gas Barrier archetype scripts and register them in a shared ability catalog
- introduce a StatusManager with immunity and self-damage logic and integrate resource/status support into PlayerAvatar

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1a787f66c8329b1a38233761158c8