### PR TITLE
Add particle and element class database with tests

### DIFF
--- a/data/classes/classes.json
+++ b/data/classes/classes.json
@@ -1,0 +1,257 @@
+{
+  "standard_model": {
+    "quarks": [
+      {
+        "id": "quark_up",
+        "display_name": "Up Quark",
+        "lore": "Lightweight member of the first-generation quark pair, excels at evasive manoeuvres while weaving colour charge bonds.",
+        "base_stats": {"mass_mev": 2.3, "charge": 0.666, "stability": 0.9, "spin": 0.5},
+        "ability_tags": ["agile_skirmisher", "color_binding", "baryon_synergy"]
+      },
+      {
+        "id": "quark_down",
+        "display_name": "Down Quark",
+        "lore": "Sturdy partner to the up quark that anchors hadronic combos and shoulders extra mass for team durability.",
+        "base_stats": {"mass_mev": 4.8, "charge": -0.333, "stability": 0.85, "spin": 0.5},
+        "ability_tags": ["baryon_synergy", "defense_anchor", "color_binding"]
+      },
+      {
+        "id": "quark_charm",
+        "display_name": "Charm Quark",
+        "lore": "Second-generation quark that dazzles with high-energy bursts before its unstable resonance collapses.",
+        "base_stats": {"mass_mev": 1275.0, "charge": 0.666, "stability": 0.35, "spin": 0.5},
+        "ability_tags": ["burst_damage", "unstable_decay", "color_binding"]
+      },
+      {
+        "id": "quark_strange",
+        "display_name": "Strange Quark",
+        "lore": "Quark aligned to eerie weak-force twists that inflict lingering status effects while juggling colour locks.",
+        "base_stats": {"mass_mev": 95.0, "charge": -0.333, "stability": 0.4, "spin": 0.5},
+        "ability_tags": ["status_decay", "debuff_specialist", "color_binding"]
+      },
+      {
+        "id": "quark_top",
+        "display_name": "Top Quark",
+        "lore": "Heaviest known quark whose catastrophic collapses fuel ultimate-scale strikes before it evaporates.",
+        "base_stats": {"mass_mev": 172900.0, "charge": 0.666, "stability": 0.1, "spin": 0.5},
+        "ability_tags": ["ultimate_overclock", "unstable_decay", "color_binding"]
+      },
+      {
+        "id": "quark_bottom",
+        "display_name": "Bottom Quark",
+        "lore": "Massive flavour tuned for gravity-laden finishers that reward careful timing of its rapid decay chain.",
+        "base_stats": {"mass_mev": 4180.0, "charge": -0.333, "stability": 0.15, "spin": 0.5},
+        "ability_tags": ["gravity_crush", "unstable_decay", "color_binding"]
+      }
+    ],
+    "leptons": [
+      {
+        "id": "lepton_electron",
+        "display_name": "Electron",
+        "lore": "Everyday lepton hero that zips through circuits, orbiting objectives with precision electric attacks.",
+        "base_stats": {"mass_mev": 0.511, "charge": -1.0, "stability": 0.95, "spin": 0.5},
+        "ability_tags": ["orbital_dash", "electric_tricks", "tech_interface"]
+      },
+      {
+        "id": "lepton_electron_neutrino",
+        "display_name": "Electron Neutrino",
+        "lore": "Ghostly infiltrator who phases through hazards, interacting only when and where it chooses.",
+        "base_stats": {"mass_mev": 0.000002, "charge": 0.0, "stability": 0.9, "spin": 0.5},
+        "ability_tags": ["phase_shift", "stealth_specialist", "weak_interaction"]
+      },
+      {
+        "id": "lepton_muon",
+        "display_name": "Muon",
+        "lore": "Heavy cousin of the electron delivering brutal impulse strikes before its fleeting life expires.",
+        "base_stats": {"mass_mev": 105.7, "charge": -1.0, "stability": 0.25, "spin": 0.5},
+        "ability_tags": ["burst_damage", "decay_timer", "electric_tricks"]
+      },
+      {
+        "id": "lepton_tau",
+        "display_name": "Tau",
+        "lore": "Ultra-massive lepton that weaponises gravitational dives and sacrificial detonations.",
+        "base_stats": {"mass_mev": 1776.9, "charge": -1.0, "stability": 0.1, "spin": 0.5},
+        "ability_tags": ["gravity_crush", "decay_timer", "berserker"]
+      }
+    ],
+    "bosons": [
+      {
+        "id": "boson_photon",
+        "display_name": "Photon",
+        "lore": "Massless courier of light whose instant travel and dazzling beams favour high-risk positioning.",
+        "base_stats": {"mass_mev": 0.0, "charge": 0.0, "stability": 1.0, "spin": 1.0},
+        "ability_tags": ["speed_blink", "light_control", "glass_cannon"]
+      },
+      {
+        "id": "boson_gluon",
+        "display_name": "Gluon",
+        "lore": "Strong-force avatar weaving allies together with unbreakable tethers and shielding bonds.",
+        "base_stats": {"mass_mev": 0.0, "charge": 0.0, "stability": 0.8, "spin": 1.0},
+        "ability_tags": ["binding_fields", "team_link", "color_binding"]
+      },
+      {
+        "id": "boson_w",
+        "display_name": "W Boson",
+        "lore": "Charged weak-force brute unleashing polarity-flipping blasts with punishing recoil.",
+        "base_stats": {"mass_mev": 80390.0, "charge": 1.0, "stability": 0.05, "spin": 1.0},
+        "ability_tags": ["charge_burst", "self_recoil", "weak_interaction"]
+      },
+      {
+        "id": "boson_z",
+        "display_name": "Z Boson",
+        "lore": "Neutral weak mediator channelling devastating area pulses at the cost of self-harm.",
+        "base_stats": {"mass_mev": 91190.0, "charge": 0.0, "stability": 0.05, "spin": 1.0},
+        "ability_tags": ["area_pulse", "self_recoil", "weak_interaction"]
+      },
+      {
+        "id": "boson_higgs",
+        "display_name": "Higgs Boson",
+        "lore": "Elusive mass-granter that amplifies allies by seeding temporary mass and resilience.",
+        "base_stats": {"mass_mev": 125090.0, "charge": 0.0, "stability": 0.5, "spin": 0.0},
+        "ability_tags": ["mass_boost", "support_aura", "rarity_event"]
+      }
+    ]
+  },
+  "periodic": {
+    "alkali_metals": [
+      {
+        "id": "element_lithium",
+        "display_name": "Lithium",
+        "lore": "Soft alkali scout that sparks volatile dashes and ignites terrain upon impact.",
+        "base_stats": {"atomic_mass": 6.94, "charge": 1.0, "stability": 0.7, "reactivity": 0.95},
+        "ability_tags": ["reactive_burst", "flammable_dash", "fragile_metal"]
+      },
+      {
+        "id": "element_sodium",
+        "display_name": "Sodium",
+        "lore": "Explosive frontline striker whose contact attacks erupt in caustic sprays when doused.",
+        "base_stats": {"atomic_mass": 22.99, "charge": 1.0, "stability": 0.6, "reactivity": 0.98},
+        "ability_tags": ["reactive_burst", "caustic_wash", "fragile_metal"]
+      },
+      {
+        "id": "element_potassium",
+        "display_name": "Potassium",
+        "lore": "Heavier alkali duelist blending poisonous lye strikes with chain reactions.",
+        "base_stats": {"atomic_mass": 39.10, "charge": 1.0, "stability": 0.55, "reactivity": 0.97},
+        "ability_tags": ["reactive_burst", "poison_lash", "fragile_metal"]
+      }
+    ],
+    "alkaline_earth_metals": [
+      {
+        "id": "element_magnesium",
+        "display_name": "Magnesium",
+        "lore": "Radiant support bruiser that burns white-hot to blind foes and kindle machinery.",
+        "base_stats": {"atomic_mass": 24.31, "charge": 2.0, "stability": 0.75, "reactivity": 0.8},
+        "ability_tags": ["radiant_fire", "blinding_flare", "steady_guard"]
+      },
+      {
+        "id": "element_calcium",
+        "display_name": "Calcium",
+        "lore": "Builder guardian forging calcium-rich barriers and reinforcing allies' structure.",
+        "base_stats": {"atomic_mass": 40.08, "charge": 2.0, "stability": 0.78, "reactivity": 0.7},
+        "ability_tags": ["radiant_fire", "fortify_builder", "steady_guard"]
+      }
+    ],
+    "chalcogens": [
+      {
+        "id": "element_oxygen",
+        "display_name": "Oxygen",
+        "lore": "Vital support catalyst that breathes fire into allies and revives dormant engines.",
+        "base_stats": {"atomic_mass": 16.00, "charge": -2.0, "stability": 0.85, "reactivity": 0.9},
+        "ability_tags": ["support_oxygenate", "flame_boost", "life_breath"]
+      },
+      {
+        "id": "element_sulfur",
+        "display_name": "Sulfur",
+        "lore": "Acrid controller spreading choking clouds and alchemical traps.",
+        "base_stats": {"atomic_mass": 32.06, "charge": -2.0, "stability": 0.7, "reactivity": 0.88},
+        "ability_tags": ["support_oxygenate", "poison_cloud", "alchemical_traps"]
+      }
+    ],
+    "halogens": [
+      {
+        "id": "element_fluorine",
+        "display_name": "Fluorine",
+        "lore": "Razor reactive striker that corrodes armour instantly and amplifies allied burns.",
+        "base_stats": {"atomic_mass": 19.00, "charge": -1.0, "stability": 0.4, "reactivity": 1.0},
+        "ability_tags": ["corrosive_cloud", "reactive_burst", "toxicity_mastery"]
+      },
+      {
+        "id": "element_chlorine",
+        "display_name": "Chlorine",
+        "lore": "Lingering gas assassin laying poisonous traps and dissolving barriers.",
+        "base_stats": {"atomic_mass": 35.45, "charge": -1.0, "stability": 0.5, "reactivity": 0.95},
+        "ability_tags": ["corrosive_cloud", "area_denial", "toxicity_mastery"]
+      },
+      {
+        "id": "element_iodine",
+        "display_name": "Iodine",
+        "lore": "Pungent debuffer sowing blindness and hexes from a distance.",
+        "base_stats": {"atomic_mass": 126.90, "charge": -1.0, "stability": 0.6, "reactivity": 0.85},
+        "ability_tags": ["corrosive_cloud", "vision_hex", "toxicity_mastery"]
+      }
+    ],
+    "noble_gases": [
+      {
+        "id": "element_helium",
+        "display_name": "Helium",
+        "lore": "Playful uplift specialist that grants levitation and laughter to disarm foes.",
+        "base_stats": {"atomic_mass": 4.00, "charge": 0.0, "stability": 0.95, "reactivity": 0.05},
+        "ability_tags": ["support_inert", "levitation_aura", "crowd_confuse"]
+      },
+      {
+        "id": "element_neon",
+        "display_name": "Neon",
+        "lore": "Luminous tactician illuminating arenas and cloaking allies in dazzling veils.",
+        "base_stats": {"atomic_mass": 20.18, "charge": 0.0, "stability": 0.96, "reactivity": 0.05},
+        "ability_tags": ["support_inert", "light_control", "crowd_confuse"]
+      },
+      {
+        "id": "element_argon",
+        "display_name": "Argon",
+        "lore": "Stoic protector projecting inert shields that insulate allies from harm.",
+        "base_stats": {"atomic_mass": 39.95, "charge": 0.0, "stability": 0.97, "reactivity": 0.05},
+        "ability_tags": ["support_inert", "shielding_field", "light_control"]
+      }
+    ],
+    "transition_metals": [
+      {
+        "id": "element_iron",
+        "display_name": "Iron",
+        "lore": "Armoured juggernaut leveraging magnetic pulls to dominate the battlefield.",
+        "base_stats": {"atomic_mass": 55.85, "charge": 2.0, "stability": 0.8, "reactivity": 0.5},
+        "ability_tags": ["magnetic_control", "heavy_armor", "forge_mastery"]
+      },
+      {
+        "id": "element_copper",
+        "display_name": "Copper",
+        "lore": "Conductive support hacking devices and chaining electric discharges.",
+        "base_stats": {"atomic_mass": 63.55, "charge": 1.0, "stability": 0.82, "reactivity": 0.55},
+        "ability_tags": ["magnetic_control", "electric_tricks", "trade_bonus"]
+      },
+      {
+        "id": "element_gold",
+        "display_name": "Gold",
+        "lore": "Noble metal mastermind who manipulates wealth flows and resists corrosion.",
+        "base_stats": {"atomic_mass": 196.97, "charge": 1.0, "stability": 0.9, "reactivity": 0.3},
+        "ability_tags": ["magnetic_control", "luck_aura", "trade_bonus"]
+      }
+    ],
+    "radioactive_metals": [
+      {
+        "id": "element_uranium",
+        "display_name": "Uranium",
+        "lore": "Apocalyptic artillery that triggers chain fission blasts with lingering fallout.",
+        "base_stats": {"atomic_mass": 238.03, "charge": 6.0, "stability": 0.2, "reactivity": 0.92},
+        "ability_tags": ["radiation_aoe", "delayed_burst", "hazard_zone"]
+      },
+      {
+        "id": "element_thorium",
+        "display_name": "Thorium",
+        "lore": "Long-burn reactor tank feeding allies while radiating persistent damage fields.",
+        "base_stats": {"atomic_mass": 232.04, "charge": 4.0, "stability": 0.35, "reactivity": 0.85},
+        "ability_tags": ["radiation_aoe", "support_reactor", "hazard_zone"]
+      }
+    ]
+  }
+}

--- a/scripts/data/class_database.gd
+++ b/scripts/data/class_database.gd
@@ -1,0 +1,129 @@
+extends Node
+class_name ClassDatabase
+
+const DATA_PATH := "res://data/classes/classes.json"
+const STANDARD_MODEL_GROUPS := PackedStringArray(["quarks", "leptons", "bosons"])
+const PERIODIC_GROUPS := PackedStringArray([
+    "alkali_metals",
+    "alkaline_earth_metals",
+    "chalcogens",
+    "halogens",
+    "noble_gases",
+    "transition_metals",
+    "radioactive_metals",
+])
+
+var _entries_by_id: Dictionary = {}
+var _entries_by_category: Dictionary = {}
+var _entries_by_group: Dictionary = {}
+
+func _init() -> void:
+    load_data()
+
+func load_data() -> void:
+    var file := FileAccess.open(DATA_PATH, FileAccess.READ)
+    if file == null:
+        push_error("ClassDatabase: Unable to open data file %s" % DATA_PATH)
+        return
+    var text := file.get_as_text()
+    file.close()
+    var parsed := JSON.parse_string(text)
+    if typeof(parsed) != TYPE_DICTIONARY:
+        push_error("ClassDatabase: Data root must be a dictionary")
+        return
+    _entries_by_id.clear()
+    _entries_by_category.clear()
+    _entries_by_group.clear()
+    for category in parsed.keys():
+        var group_dict = parsed[category]
+        if typeof(group_dict) != TYPE_DICTIONARY:
+            push_warning("ClassDatabase: Category %s is not a dictionary" % category)
+            continue
+        _entries_by_category[category] = []
+        _entries_by_group[category] = {}
+        var expected_groups := _get_expected_groups(category)
+        for group_name in group_dict.keys():
+            var entries = group_dict[group_name]
+            if typeof(entries) != TYPE_ARRAY:
+                push_warning("ClassDatabase: Group %s/%s is not an array" % [category, group_name])
+                continue
+            _entries_by_group[category][group_name] = []
+            if expected_groups.size() > 0 and not expected_groups.has(group_name):
+                push_warning("ClassDatabase: Group %s unexpected for category %s" % [group_name, category])
+            for entry in entries:
+                if typeof(entry) != TYPE_DICTIONARY:
+                    push_warning("ClassDatabase: Entry in %s/%s is not a dictionary" % [category, group_name])
+                    continue
+                var id: String = entry.get("id", "")
+                if id.is_empty():
+                    push_warning("ClassDatabase: Entry missing id in %s/%s" % [category, group_name])
+                    continue
+                var enriched := entry.duplicate(true)
+                enriched["category"] = category
+                enriched["group"] = group_name
+                _entries_by_id[id] = enriched
+                _entries_by_category[category].append(enriched)
+                _entries_by_group[category][group_name].append(enriched)
+        if expected_groups.size() > 0:
+            for missing in expected_groups:
+                if not _entries_by_group[category].has(missing):
+                    _entries_by_group[category][missing] = []
+
+func get_categories() -> PackedStringArray:
+    var categories := PackedStringArray()
+    for category in _entries_by_category.keys():
+        categories.append(String(category))
+    return categories
+
+func get_category_groups(category: String) -> PackedStringArray:
+    if not _entries_by_group.has(category):
+        return PackedStringArray()
+    var groups := PackedStringArray()
+    for group_name in _entries_by_group[category].keys():
+        groups.append(String(group_name))
+    return groups
+
+func get_classes_in_category(category: String) -> Array:
+    return _entries_by_category.get(category, []).duplicate()
+
+func get_classes_in_group(category: String, group_name: String) -> Array:
+    if not _entries_by_group.has(category):
+        return []
+    return _entries_by_group[category].get(group_name, []).duplicate()
+
+func get_class_ids() -> PackedStringArray:
+    var ids := PackedStringArray()
+    for id in _entries_by_id.keys():
+        ids.append(String(id))
+    return ids
+
+func has_class(id: String) -> bool:
+    return _entries_by_id.has(id)
+
+func get_class(id: String) -> Dictionary:
+    if not _entries_by_id.has(id):
+        return {}
+    return _entries_by_id[id].duplicate(true)
+
+func get_group_tags(category: String, group_name: String) -> PackedStringArray:
+    var tag_set: Dictionary = {}
+    for entry in get_classes_in_group(category, group_name):
+        var tags: Array = entry.get("ability_tags", [])
+        for tag in tags:
+            tag_set[String(tag)] = true
+    var packed := PackedStringArray()
+    for tag in tag_set.keys():
+        packed.append(String(tag))
+    return packed
+
+func get_expected_groups_for_category(category: String) -> PackedStringArray:
+    return _get_expected_groups(category)
+
+func _get_expected_groups(category: String) -> PackedStringArray:
+    match category:
+        "standard_model":
+            return STANDARD_MODEL_GROUPS
+        "periodic":
+            return PERIODIC_GROUPS
+        _:
+            return PackedStringArray()

--- a/tests/test_class_database.gd
+++ b/tests/test_class_database.gd
@@ -1,0 +1,47 @@
+extends GutTest
+
+var _db: ClassDatabase
+
+func before_all() -> void:
+    _db = ClassDatabase.new()
+    _db.load_data()
+
+func test_all_entries_have_required_fields() -> void:
+    var required_fields := ["display_name", "lore", "base_stats", "ability_tags"]
+    for class_id in _db.get_class_ids():
+        var entry := _db.get_class(class_id)
+        assert_true(entry.size() > 0, "Expected data for %s" % class_id)
+        for field in required_fields:
+            assert_true(entry.has(field), "%s missing %s" % [class_id, field])
+        var stats := entry.get("base_stats", null)
+        assert_true(stats is Dictionary, "%s base_stats should be a dictionary" % class_id)
+        assert_true(stats.has("charge"), "%s base stats missing charge" % class_id)
+        assert_true(stats.has("stability"), "%s base stats missing stability" % class_id)
+        assert_true(
+            stats.has("mass_mev") or stats.has("atomic_mass"),
+            "%s base stats missing mass field" % class_id
+        )
+        var ability_tags := entry.get("ability_tags", [])
+        assert_true(ability_tags is Array and ability_tags.size() > 0, "%s requires at least one ability tag" % class_id)
+
+func test_standard_model_groups_populated() -> void:
+    var expected := _db.get_expected_groups_for_category("standard_model")
+    for group_name in expected:
+        var entries := _db.get_classes_in_group("standard_model", group_name)
+        assert_true(entries.size() > 0, "Expected members in standard model group %s" % group_name)
+
+func test_noble_gases_share_support_tag() -> void:
+    var noble_gases := _db.get_classes_in_group("periodic", "noble_gases")
+    assert_true(noble_gases.size() >= 3, "Expected at least three noble gas entries")
+    for entry in noble_gases:
+        var tags: Array = entry.get("ability_tags", [])
+        assert_true(tags.has("support_inert"), "%s should include support_inert tag" % entry.get("id", entry.get("display_name")))
+
+func test_alkali_metals_are_reactive() -> void:
+    var alkali := _db.get_classes_in_group("periodic", "alkali_metals")
+    assert_true(alkali.size() >= 2, "Expected at least two alkali metals")
+    for entry in alkali:
+        var stats := entry.get("base_stats", {})
+        assert_true(stats.get("reactivity", 0.0) >= 0.9, "%s should have high reactivity" % entry.get("id", entry.get("display_name")))
+        var tags: Array = entry.get("ability_tags", [])
+        assert_true(tags.has("reactive_burst"), "%s should include reactive_burst tag" % entry.get("id", entry.get("display_name")))


### PR DESCRIPTION
## Summary
- add a JSON dataset that describes Standard Model particles and periodic element archetypes with stats and ability tags
- add a ClassDatabase singleton for loading the dataset, grouping entries, and exposing lookup helpers
- add GUT unit tests to validate required fields and shared group traits like noble gas inert support roles

## Testing
- not run (Godot)

------
https://chatgpt.com/codex/tasks/task_e_68e1aa18c0f08329bae89ae1bf30c138