### PR TITLE
Add character selection UI with unlockable classes

### DIFF
--- a/scenes/levels/chemical_vat_prototype.tscn
+++ b/scenes/levels/chemical_vat_prototype.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/chemical_vat.tscn" id="2"]
+[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="3"]
 
 [node name="ChemicalVatPrototype" type="Node2D"]
 
@@ -15,3 +16,7 @@ base_keywords = [&"corrosive"]
 
 [node name="ChemicalVat" parent="." instance=ExtResource("2")]
 position = Vector2(0, 0)
+
+[node name="GameController" type="Node" parent="."]
+script = ExtResource("3")
+player_path = NodePath("../ExplosiveCrafter")

--- a/scenes/levels/electric_field_prototype.tscn
+++ b/scenes/levels/electric_field_prototype.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/electric_field.tscn" id="2"]
+[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="3"]
 
 [node name="ElectricFieldPrototype" type="Node2D"]
 
@@ -10,3 +11,7 @@ position = Vector2(0, -220)
 
 [node name="ElectricField" parent="." instance=ExtResource("2")]
 position = Vector2(0, 0)
+
+[node name="GameController" type="Node" parent="."]
+script = ExtResource("3")
+player_path = NodePath("../Player")

--- a/scenes/levels/magnetic_trap_prototype.tscn
+++ b/scenes/levels/magnetic_trap_prototype.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=5 format=3]
 
 [ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/magnetic_trap.tscn" id="2"]
 [ext_resource type="Resource" path="res://data/classes/particles/down_quark.tres" id="3"]
+[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="4"]
 
 [node name="MagneticTrapPrototype" type="Node2D"]
 
@@ -18,3 +19,7 @@ particle_class = ExtResource("3")
 
 [node name="MagneticTrap" parent="." instance=ExtResource("2")]
 position = Vector2(0, 0)
+
+[node name="GameController" type="Node" parent="."]
+script = ExtResource("4")
+player_path = NodePath("../UpQuark2")

--- a/scenes/levels/radiation_zone_prototype.tscn
+++ b/scenes/levels/radiation_zone_prototype.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=5 format=3]
 
 [ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/radiation_zone.tscn" id="2"]
 [ext_resource type="Resource" path="res://data/classes/particles/electron_neutrino.tres" id="3"]
+[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="4"]
 
 [node name="RadiationZonePrototype" type="Node2D"]
 
@@ -15,3 +16,7 @@ particle_class = ExtResource("3")
 
 [node name="RadiationZone" parent="." instance=ExtResource("2")]
 position = Vector2(0, 0)
+
+[node name="GameController" type="Node" parent="."]
+script = ExtResource("4")
+player_path = NodePath("../Electron")

--- a/scenes/ui/character_select.tscn
+++ b/scenes/ui/character_select.tscn
@@ -1,0 +1,39 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/character_select.gd" id="1"]
+
+[node name="CharacterSelect" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 24
+custom_constants/margin_top = 24
+custom_constants/margin_right = 24
+custom_constants/margin_bottom = 24
+
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/MarginContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/separation = 16
+
+[node name="StatusLabel" type="Label" parent="PanelContainer/MarginContainer/VBoxContainer"]
+text = "Select a particle archetype to begin."
+autowrap_mode = 3
+
+[node name="ScrollContainer" type="ScrollContainer" parent="PanelContainer/MarginContainer/VBoxContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_vertical = 3
+size_flags_horizontal = 3
+
+[node name="ClassList" type="VBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer/ScrollContainer"]
+custom_constants/separation = 12
+size_flags_horizontal = 3

--- a/scripts/game/game_controller.gd
+++ b/scripts/game/game_controller.gd
@@ -1,0 +1,151 @@
+extends Node
+class_name GameController
+
+const ParticleClassDefinition := preload("res://scripts/classes/particle_class.gd")
+const PlayerAvatar := preload("res://scripts/player/player_avatar.gd")
+const UnlockManager := preload("res://scripts/progression/unlock_manager.gd")
+const CharacterSelectScene := preload("res://scenes/ui/character_select.tscn")
+
+const ABILITY_SCRIPTS := {
+    "color_dash": preload("res://scripts/abilities/color_dash.gd"),
+    "color_field": preload("res://scripts/abilities/color_field.gd"),
+    "fusion_lock": preload("res://scripts/abilities/fusion_lock.gd"),
+    "hadronize": preload("res://scripts/abilities/hadronize.gd"),
+    "annihilation_wave": preload("res://scripts/abilities/annihilation_wave.gd"),
+    "gamma_burst": preload("res://scripts/abilities/gamma_burst.gd"),
+    "photon_dash": preload("res://scripts/abilities/photon_dash.gd"),
+    "photon_pulse": preload("res://scripts/abilities/photon_pulse.gd"),
+    "gluon_bind": preload("res://scripts/abilities/gluon_bind.gd"),
+    "ion_field": preload("res://scripts/abilities/ion_field.gd"),
+    "noble_gas_barrier": preload("res://scripts/abilities/noble_gas_barrier.gd"),
+    "halogen_corrosion": preload("res://scripts/abilities/halogen_corrosion.gd"),
+    "higgs_mass_boost": preload("res://scripts/abilities/higgs_mass_boost.gd"),
+    "mass_anchor": preload("res://scripts/abilities/mass_anchor.gd"),
+    "neutral_screen": preload("res://scripts/abilities/neutral_screen.gd"),
+    "w_blast": preload("res://scripts/abilities/w_blast.gd"),
+    "z_pulse": preload("res://scripts/abilities/z_pulse.gd"),
+    "weak_flux": preload("res://scripts/abilities/weak_flux.gd"),
+    "downward_smash": preload("res://scripts/abilities/downward_smash.gd"),
+    "phase_shift": preload("res://scripts/abilities/phase_shift.gd"),
+    "ghost_walk": preload("res://scripts/abilities/ghost_walk.gd"),
+    "chain_discharge": preload("res://scripts/abilities/chain_discharge.gd"),
+    "orbital_strike": preload("res://scripts/abilities/orbital_strike.gd"),
+    "inertial_field": preload("res://scripts/abilities/inertial_field.gd"),
+    "beta_decay": preload("res://scripts/abilities/beta_decay.gd"),
+    "higgs_resonance": preload("res://scripts/abilities/higgs_resonance.gd"),
+    "weak_charge_field": preload("res://scripts/abilities/weak_charge_field.gd"),
+    "fractional_charge": preload("res://scripts/abilities/fractional_charge.gd"),
+    "baryon_wall": preload("res://scripts/abilities/baryon_wall.gd"),
+}
+
+const CLASS_LOADOUTS := {
+    "quark_up": {"active": "color_dash", "passive": "color_field", "ultimate": "fusion_lock"},
+    "quark_down": {"active": "mass_anchor", "passive": "color_field", "ultimate": "hadronize"},
+    "quark_charm": {"active": "color_dash", "passive": "weak_flux", "ultimate": "annihilation_wave"},
+    "quark_strange": {"active": "halogen_corrosion", "passive": "weak_flux", "ultimate": "beta_decay"},
+    "quark_top": {"active": "downward_smash", "passive": "fusion_lock", "ultimate": "annihilation_wave"},
+    "quark_bottom": {"active": "mass_anchor", "passive": "weak_flux", "ultimate": "beta_decay"},
+    "lepton_electron": {"active": "photon_dash", "passive": "photon_pulse", "ultimate": "gamma_burst"},
+    "lepton_electron_neutrino": {"active": "phase_shift", "passive": "ghost_walk", "ultimate": "neutral_screen"},
+    "lepton_muon": {"active": "photon_dash", "passive": "ion_field", "ultimate": "gamma_burst"},
+    "lepton_tau": {"active": "downward_smash", "passive": "ion_field", "ultimate": "annihilation_wave"},
+    "boson_photon": {"active": "photon_dash", "passive": "photon_pulse", "ultimate": "gamma_burst"},
+    "boson_gluon": {"active": "gluon_bind", "passive": "color_field", "ultimate": "fusion_lock"},
+    "boson_w": {"active": "w_blast", "passive": "weak_flux", "ultimate": "annihilation_wave"},
+    "boson_z": {"active": "z_pulse", "passive": "weak_flux", "ultimate": "neutral_screen"},
+    "boson_higgs": {"active": "higgs_resonance", "passive": "higgs_mass_boost", "ultimate": "mass_anchor"},
+    "element_lithium": {"active": "chain_discharge", "passive": "ion_field", "ultimate": "orbital_strike"},
+    "element_sodium": {"active": "chain_discharge", "passive": "ion_field", "ultimate": "orbital_strike"},
+    "element_potassium": {"active": "chain_discharge", "passive": "ion_field", "ultimate": "orbital_strike"},
+    "element_magnesium": {"active": "fusion_lock", "passive": "noble_gas_barrier", "ultimate": "orbital_strike"},
+    "element_calcium": {"active": "mass_anchor", "passive": "noble_gas_barrier", "ultimate": "orbital_strike"},
+    "element_oxygen": {"active": "halogen_corrosion", "passive": "ion_field", "ultimate": "gamma_burst"},
+    "element_sulfur": {"active": "halogen_corrosion", "passive": "ion_field", "ultimate": "gamma_burst"},
+    "element_fluorine": {"active": "halogen_corrosion", "passive": "ion_field", "ultimate": "orbital_strike"},
+    "element_chlorine": {"active": "halogen_corrosion", "passive": "ion_field", "ultimate": "orbital_strike"},
+    "element_iodine": {"active": "halogen_corrosion", "passive": "ion_field", "ultimate": "orbital_strike"},
+    "element_helium": {"active": "neutral_screen", "passive": "noble_gas_barrier", "ultimate": "mass_anchor"},
+    "element_neon": {"active": "neutral_screen", "passive": "noble_gas_barrier", "ultimate": "orbital_strike"},
+    "element_argon": {"active": "neutral_screen", "passive": "noble_gas_barrier", "ultimate": "orbital_strike"},
+    "element_iron": {"active": "mass_anchor", "passive": "inertial_field", "ultimate": "orbital_strike"},
+    "element_copper": {"active": "chain_discharge", "passive": "ion_field", "ultimate": "orbital_strike"},
+    "element_gold": {"active": "mass_anchor", "passive": "inertial_field", "ultimate": "orbital_strike"},
+    "element_uranium": {"active": "halogen_corrosion", "passive": "beta_decay", "ultimate": "annihilation_wave"},
+    "element_thorium": {"active": "halogen_corrosion", "passive": "beta_decay", "ultimate": "annihilation_wave"},
+}
+
+@export var player_path: NodePath
+@export var show_selection_on_ready: bool = true
+
+signal run_started(class_data: Dictionary, particle_class: ParticleClassDefinition)
+
+var _unlock_manager := UnlockManager.new()
+var _selection_ui: Control
+var _player: PlayerAvatar
+
+func _ready() -> void:
+    _resolve_player()
+    if show_selection_on_ready:
+        open_character_select()
+
+func open_character_select() -> void:
+    if _selection_ui == null:
+        _selection_ui = CharacterSelectScene.instantiate()
+        add_child(_selection_ui)
+        if _selection_ui.has_method("set_unlock_manager"):
+            _selection_ui.set_unlock_manager(_unlock_manager)
+        if _selection_ui.has_signal("class_chosen"):
+            _selection_ui.connect("class_chosen", Callable(self, "_on_class_chosen"))
+    _selection_ui.visible = true
+
+func _on_class_chosen(class_data: Dictionary) -> void:
+    var particle_class := _build_particle_class(class_data)
+    if particle_class == null:
+        push_warning("GameController: Unable to build particle class for %s" % class_data.get("id", "unknown"))
+        return
+    _resolve_player()
+    if is_instance_valid(_player):
+        _player.set_particle_class(particle_class)
+    emit_signal("run_started", class_data, particle_class)
+    if is_instance_valid(_selection_ui):
+        _selection_ui.hide()
+
+func _build_particle_class(class_data: Dictionary) -> ParticleClassDefinition:
+    if class_data.is_empty():
+        return null
+    var definition := ParticleClassDefinition.new()
+    definition.id = StringName(class_data.get("id", ""))
+    definition.display_name = String(class_data.get("display_name", ""))
+    definition.description = String(class_data.get("lore", ""))
+
+    var base_stats := class_data.get("base_stats", {})
+    if typeof(base_stats) == TYPE_DICTIONARY:
+        if base_stats.has("mass_mev"):
+            definition.mass = float(base_stats.get("mass_mev", definition.mass))
+        elif base_stats.has("atomic_mass"):
+            definition.mass = float(base_stats.get("atomic_mass", definition.mass))
+        definition.charge = float(base_stats.get("charge", definition.charge))
+        definition.stability = float(base_stats.get("stability", definition.stability))
+
+    var loadout_ids := CLASS_LOADOUTS.get(String(class_data.get("id", "")), {})
+    definition.active_ability = _ability_from_id(loadout_ids.get("active", ""))
+    definition.passive_ability = _ability_from_id(loadout_ids.get("passive", ""))
+    definition.ultimate_ability = _ability_from_id(loadout_ids.get("ultimate", ""))
+    return definition
+
+func _ability_from_id(id: String) -> Script:
+    if id.is_empty():
+        return null
+    if not ABILITY_SCRIPTS.has(id):
+        push_warning("GameController: Ability id %s not registered." % id)
+        return null
+    return ABILITY_SCRIPTS[id]
+
+func _resolve_player() -> void:
+    if is_instance_valid(_player):
+        return
+    if player_path.is_empty():
+        return
+    var node := get_node_or_null(player_path)
+    if node and node is PlayerAvatar:
+        _player = node

--- a/scripts/progression/unlock_manager.gd
+++ b/scripts/progression/unlock_manager.gd
@@ -1,0 +1,123 @@
+extends Node
+class_name UnlockManager
+
+const STORAGE_PATH := "user://progression_state.json"
+
+var _runs_completed: int = 0
+var _manual_unlocks: Dictionary = {}
+
+func _init() -> void:
+    _load_state()
+
+func record_run_completed() -> void:
+    _runs_completed += 1
+    _save_state()
+
+func unlock_class(id: StringName) -> void:
+    id = StringName(id)
+    if _manual_unlocks.get(id, false):
+        return
+    _manual_unlocks[id] = true
+    _save_state()
+
+func is_class_unlocked(class_data: Dictionary) -> bool:
+    var id := StringName(class_data.get("id", ""))
+    if id.is_empty():
+        return false
+    if _manual_unlocks.get(id, false):
+        return true
+    var requirement := get_unlock_requirement(class_data)
+    if requirement.is_empty():
+        return true
+    match requirement.get("type", ""):
+        "runs_completed":
+            return _runs_completed >= int(requirement.get("runs", 0))
+        _:
+            return true
+
+func get_unlock_requirement(class_data: Dictionary) -> Dictionary:
+    var stats: Dictionary = class_data.get("base_stats", {})
+    if stats.is_empty():
+        return {}
+    if stats.has("mass_mev"):
+        return _get_mass_requirement(float(stats.get("mass_mev", 0.0)))
+    if stats.has("atomic_mass"):
+        return _get_mass_requirement(float(stats.get("atomic_mass", 0.0)))
+    if stats.has("reactivity"):
+        var value := float(stats.get("reactivity", 0.0))
+        if value >= 0.95:
+            return {
+                "type": "runs_completed",
+                "runs": 3,
+                "description": "Complete 3 runs to stabilise highly reactive elements.",
+            }
+    return {}
+
+func describe_requirement(requirement: Dictionary) -> String:
+    if requirement.is_empty():
+        return ""
+    match requirement.get("type", ""):
+        "runs_completed":
+            var runs := int(requirement.get("runs", 0))
+            if requirement.has("description") and not String(requirement["description"]).is_empty():
+                return String(requirement["description"])
+            if runs <= 1:
+                return "Complete 1 run to unlock."
+            return "Complete %d runs to unlock." % runs
+        _:
+            return String(requirement.get("description", ""))
+
+func get_runs_completed() -> int:
+    return _runs_completed
+
+func _get_mass_requirement(mass: float) -> Dictionary:
+    if mass >= 100000.0:
+        return {
+            "type": "runs_completed",
+            "runs": 5,
+            "description": "Complete 5 runs to stabilise ultra-heavy generations.",
+        }
+    if mass >= 1000.0:
+        return {
+            "type": "runs_completed",
+            "runs": 3,
+            "description": "Complete 3 runs to unlock high-mass variants.",
+        }
+    if mass >= 50.0:
+        return {
+            "type": "runs_completed",
+            "runs": 1,
+            "description": "Complete a run to access heavier generations.",
+        }
+    return {}
+
+func _load_state() -> void:
+    if not FileAccess.file_exists(STORAGE_PATH):
+        return
+    var file := FileAccess.open(STORAGE_PATH, FileAccess.READ)
+    if file == null:
+        return
+    var text := file.get_as_text()
+    file.close()
+    var data := JSON.parse_string(text)
+    if typeof(data) != TYPE_DICTIONARY:
+        return
+    _runs_completed = int(data.get("runs_completed", 0))
+    var manual := data.get("manual_unlocks", {})
+    if typeof(manual) == TYPE_DICTIONARY:
+        _manual_unlocks.clear()
+        for key in manual.keys():
+            if manual[key]:
+                _manual_unlocks[StringName(key)] = true
+
+func _save_state() -> void:
+    var file := FileAccess.open(STORAGE_PATH, FileAccess.WRITE)
+    if file == null:
+        push_warning("UnlockManager: Failed to persist progression state.")
+        return
+    var payload := {
+        "runs_completed": _runs_completed,
+        "manual_unlocks": _manual_unlocks,
+    }
+    file.store_string(JSON.stringify(payload))
+    file.close()

--- a/scripts/ui/character_select.gd
+++ b/scripts/ui/character_select.gd
@@ -1,0 +1,207 @@
+extends Control
+class_name CharacterSelect
+
+const ClassDatabase := preload("res://scripts/data/class_database.gd")
+const UnlockManager := preload("res://scripts/progression/unlock_manager.gd")
+
+signal class_chosen(class_data: Dictionary)
+
+@onready var _class_list: VBoxContainer = %ClassList
+@onready var _status_label: Label = %StatusLabel
+
+var _database: ClassDatabase
+var _unlock_manager: UnlockManager
+var _selected_panel: PanelContainer = null
+
+const TAG_SUMMARIES := {
+    "agile_skirmisher": "Thrives on rapid repositioning and precision strikes.",
+    "color_binding": "Rewards coordinating allies with tether combos.",
+    "baryon_synergy": "Leverages team combos for amplified damage.",
+    "defense_anchor": "Plays as a frontline anchor with extra resilience.",
+    "burst_damage": "Delivers burst windows that require careful timing.",
+    "unstable_decay": "Trades stability for massive spikes—manage decay carefully.",
+    "status_decay": "Stacks lingering debuffs to wear opponents down.",
+    "debuff_specialist": "Focuses on weakening enemies over time.",
+    "gravity_crush": "Channels heavy dives and ground-slam control.",
+    "orbital_dash": "Weaves constant motion and orbiting attacks.",
+    "electric_tricks": "Manipulates electric hazards for utility and damage.",
+    "tech_interface": "Excels at interfacing with objectives and devices.",
+    "phase_shift": "Specialises in phasing through threats and stealth.",
+    "stealth_specialist": "Rewards staying unseen until the decisive strike.",
+    "weak_interaction": "Uses precision weak-force bursts with positioning demands.",
+    "decay_timer": "Operates on timers that must be refreshed or discharged.",
+    "berserker": "High risk, high reward close-range powerhouse.",
+    "speed_blink": "Relies on instant blinks and relentless tempo.",
+    "light_control": "Focuses on beams and high-energy crowd control.",
+    "glass_cannon": "Explosive damage with fragile defences—stay mobile.",
+    "binding_fields": "Supports allies with protective bonds.",
+    "team_link": "Excels when coordinating with allies.",
+    "area_pulse": "Dominates zones with heavy area pulses.",
+    "mass_boost": "Buffs allies by sharing mass and resilience.",
+    "support_aura": "Provides auras that assist the whole team.",
+    "rarity_event": "Ultimate ability shines in rare power windows.",
+    "reactive_burst": "Explodes in volatile bursts when triggered.",
+    "flammable_dash": "Ignites terrain through reckless mobility.",
+    "fragile_metal": "Glass cannon metal—strike fast before burning out.",
+    "caustic_wash": "Spreads corrosive zones that demand spacing.",
+    "poison_lash": "Stacks toxins for damage over time.",
+    "radiant_fire": "Burns brightly to blind or bombard foes.",
+    "blinding_flare": "Controls vision with intense flashes.",
+    "steady_guard": "Bolsters defences to shield allies.",
+    "fortify_builder": "Creates fortifications and defensive tools.",
+    "weak_interaction": "Uses precise weak-force manipulation to debuff foes.",
+    "support": "Provides reliable team-wide buffs.",
+    "explosive": "Turns volatility into aggressive plays.",
+    "corrosive": "Applies corrosion to soften enemy defences.",
+    "heavy_armor": "Stands firm with high durability.",
+}
+
+func set_unlock_manager(manager: UnlockManager) -> void:
+    _unlock_manager = manager
+    _refresh_entries()
+
+func _ready() -> void:
+    if _database == null:
+        _database = ClassDatabase.new()
+    if _unlock_manager == null:
+        _unlock_manager = UnlockManager.new()
+    _refresh_entries()
+
+func _refresh_entries() -> void:
+    if not is_instance_valid(_class_list):
+        return
+    for child in _class_list.get_children():
+        child.queue_free()
+    if _database == null:
+        return
+    var categories := _database.get_categories()
+    categories.sort()
+    for category in categories:
+        _class_list.add_child(_create_category_header(category))
+        var entries := _database.get_classes_in_category(category)
+        for entry in entries:
+            var panel := _create_class_panel(entry)
+            _class_list.add_child(panel)
+    _status_label.text = "Select a particle archetype to begin."
+
+func _create_category_header(category: String) -> Control:
+    var label := Label.new()
+    label.text = category.capitalize().replace("_", " ")
+    label.add_theme_color_override("font_color", Color(0.8, 0.9, 1.0, 0.85))
+    label.add_theme_font_size_override("font_size", 20)
+    label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+    label.theme_type_variation = "HeaderLarge"
+    return label
+
+func _create_class_panel(entry: Dictionary) -> PanelContainer:
+    var panel := PanelContainer.new()
+    panel.name = String(entry.get("id", ""))
+    panel.custom_minimum_size = Vector2(0, 160)
+    var wrapper := VBoxContainer.new()
+    wrapper.alignment = BoxContainer.ALIGNMENT_BEGIN
+    wrapper.add_theme_constant_override("separation", 6)
+    panel.add_child(wrapper)
+
+    var header := HBoxContainer.new()
+    header.alignment = BoxContainer.ALIGNMENT_BEGIN
+    var title := Label.new()
+    title.text = String(entry.get("display_name", "Unknown"))
+    title.add_theme_font_size_override("font_size", 18)
+    title.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+    header.add_child(title)
+
+    var select_button := Button.new()
+    var unlocked := _unlock_manager.is_class_unlocked(entry)
+    select_button.text = unlocked ? "Select" : "Locked"
+    select_button.disabled = not unlocked
+    select_button.pressed.connect(_on_class_selected.bind(entry, panel))
+    header.add_child(select_button)
+    wrapper.add_child(header)
+
+    var lore := Label.new()
+    lore.text = String(entry.get("lore", ""))
+    lore.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+    wrapper.add_child(lore)
+
+    var stats := entry.get("base_stats", {})
+    if typeof(stats) == TYPE_DICTIONARY and not stats.is_empty():
+        var stat_grid := GridContainer.new()
+        stat_grid.columns = 2
+        stat_grid.add_theme_constant_override("h_separation", 16)
+        stat_grid.add_theme_constant_override("v_separation", 2)
+        var keys := stats.keys()
+        keys.sort()
+        for key in keys:
+            var label_key := Label.new()
+            label_key.text = _format_stat_name(String(key)) + ":"
+            stat_grid.add_child(label_key)
+
+            var label_value := Label.new()
+            label_value.text = _format_stat_value(stats[key])
+            label_value.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
+            stat_grid.add_child(label_value)
+        wrapper.add_child(stat_grid)
+
+    var playstyle_label := Label.new()
+    playstyle_label.text = _build_playstyle_summary(entry)
+    playstyle_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+    wrapper.add_child(playstyle_label)
+
+    if not unlocked:
+        var requirement := _unlock_manager.get_unlock_requirement(entry)
+        var requirement_label := Label.new()
+        requirement_label.add_theme_color_override("font_color", Color(1.0, 0.55, 0.4))
+        requirement_label.text = _unlock_manager.describe_requirement(requirement)
+        requirement_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+        wrapper.add_child(requirement_label)
+
+    return panel
+
+func _on_class_selected(entry: Dictionary, panel: PanelContainer) -> void:
+    _highlight_panel(panel)
+    _status_label.text = "Selected: %s" % entry.get("display_name", "Unknown")
+    emit_signal("class_chosen", entry.duplicate(true))
+
+func _highlight_panel(panel: PanelContainer) -> void:
+    if is_instance_valid(_selected_panel):
+        _selected_panel.remove_theme_stylebox_override("panel")
+    _selected_panel = panel
+    if is_instance_valid(_selected_panel):
+        var stylebox := StyleBoxFlat.new()
+        stylebox.bg_color = Color(0.2, 0.35, 0.5, 0.3)
+        stylebox.border_color = Color(0.6, 0.8, 1.0)
+        stylebox.border_width_all = 2
+        stylebox.corner_radius_all = 4
+        _selected_panel.add_theme_stylebox_override("panel", stylebox)
+
+func _build_playstyle_summary(entry: Dictionary) -> String:
+    var tags: Array = entry.get("ability_tags", [])
+    if tags.is_empty():
+        return "Recommended playstyle: Versatile all-rounder."
+    var summaries: Array[String] = []
+    for tag in tags:
+        var key := String(tag)
+        if TAG_SUMMARIES.has(key):
+            summaries.append(TAG_SUMMARIES[key])
+    if summaries.is_empty():
+        for tag in tags:
+            var readable := String(tag).replace("_", " ")
+            readable = readable.substr(0, 1).to_upper() + readable.substr(1)
+            summaries.append(readable)
+    return "Recommended playstyle: %s" % ". ".join(summaries)
+
+func _format_stat_name(key: String) -> String:
+    key = key.replace("_", " ")
+    var words := key.split(" ")
+    for i in words.size():
+        words[i] = words[i].substr(0, 1).to_upper() + words[i].substr(1)
+    return " ".join(words)
+
+func _format_stat_value(value) -> String:
+    match typeof(value):
+        TYPE_FLOAT:
+            return "%.3f" % float(value)
+        TYPE_INT:
+            return str(int(value))
+        _:
+            return str(value)


### PR DESCRIPTION
## Summary
- add a character selection control that lists class data with stats, playstyle hints, and lock messaging
- implement a progression unlock manager that gates heavier classes behind completed runs and persists progress
- create a game controller that receives the selected class, builds loadouts, and hook prototype levels to it

## Testing
- not run (godot headless runner unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1b78418fc8329aa2e54676934b433