### PR TITLE
Add class-tag aware hazards and themed level scenes

### DIFF
--- a/scenes/hazards/charged_field.tscn
+++ b/scenes/hazards/charged_field.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/hazards/charged_field.gd" id="1"]
+
+[sub_resource type="CircleShape2D" id="1"]
+radius = 260.0
+
+[node name="ChargedField" type="Area2D"]
+script = ExtResource("1")
+field_strength = 260.0
+falloff_radius = 320.0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")

--- a/scenes/hazards/molecule_crafter.tscn
+++ b/scenes/hazards/molecule_crafter.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/hazards/molecule_crafter.gd" id="1"]
+
+[sub_resource type="CircleShape2D" id="1"]
+radius = 180.0
+
+[node name="MoleculeCrafter" type="Area2D"]
+script = ExtResource("1")
+reaction_interval = 1.1
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")

--- a/scenes/hazards/nuclear_reactor.tscn
+++ b/scenes/hazards/nuclear_reactor.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/hazards/nuclear_reactor.gd" id="1"]
+
+[sub_resource type="CircleShape2D" id="1"]
+radius = 200.0
+
+[node name="NuclearReactor" type="Area2D"]
+script = ExtResource("1")
+meltdown_threshold = 12.0
+fusion_duration = 2.5
+fission_heat = 2.2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("1")

--- a/scenes/levels/chemistry_lab.tscn
+++ b/scenes/levels/chemistry_lab.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/hazards/molecule_crafter.tscn" id="1"]
+
+[node name="ChemistryLab" type="Node2D"]
+
+[node name="CatalystCrafter" parent="." instance=ExtResource("1")]
+position = Vector2(-320, -120)
+reaction_interval = 1.4
+
+[node name="VolatileCrafter" parent="." instance=ExtResource("1")]
+position = Vector2(340, -80)
+default_duration = 1.0
+
+[node name="StabilizerCrafter" parent="." instance=ExtResource("1")]
+position = Vector2(40, 260)
+reaction_interval = 1.8
+default_duration = 2.4

--- a/scenes/levels/electromagnetism_lab.tscn
+++ b/scenes/levels/electromagnetism_lab.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/hazards/charged_field.tscn" id="1"]
+
+[node name="ElectromagnetismLab" type="Node2D"]
+
+[node name="ChargedFieldNorth" parent="." instance=ExtResource("1")]
+position = Vector2(0, -280)
+falloff_radius = 360.0
+
+[node name="ChargedFieldSouth" parent="." instance=ExtResource("1")]
+position = Vector2(0, 280)
+field_strength = 220.0
+attract_positive_charge = true
+
+[node name="ChargedFieldBridge" parent="." instance=ExtResource("1")]
+position = Vector2(360, 0)
+field_strength = 320.0
+falloff_radius = 280.0

--- a/scenes/levels/nuclear_lab.tscn
+++ b/scenes/levels/nuclear_lab.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/hazards/nuclear_reactor.tscn" id="1"]
+
+[node name="NuclearLab" type="Node2D"]
+
+[node name="CoreReactor" parent="." instance=ExtResource("1")]
+position = Vector2(0, 0)
+fusion_tags = [&"support_reactor", &"fusion_specialist", &"mass_boost"]
+fission_tags = [&"radiation_aoe", &"unstable_decay", &"hazard_zone"]
+meltdown_threshold = 14.0
+
+[node name="AuxiliaryReactor" parent="." instance=ExtResource("1")]
+position = Vector2(420, 180)
+ambient_heat_rate = 0.55
+heat_decay_rate = 0.18
+
+[node name="ContainmentReactor" parent="." instance=ExtResource("1")]
+position = Vector2(-380, -220)
+meltdown_threshold = 9.0
+fusion_cooling = 3.0

--- a/scripts/classes/particle_class.gd
+++ b/scripts/classes/particle_class.gd
@@ -16,6 +16,7 @@ class_name ParticleClassDefinition
 @export var active_ability: Script
 @export var passive_ability: Script
 @export var ultimate_ability: Script
+@export var class_tags: Array[StringName] = []
 
 func _instantiate_ability(script: Script) -> ParticleAbility:
     if script == null:

--- a/scripts/game/game_controller.gd
+++ b/scripts/game/game_controller.gd
@@ -117,6 +117,14 @@ func _build_particle_class(class_data: Dictionary) -> ParticleClassDefinition:
     definition.id = StringName(class_data.get("id", ""))
     definition.display_name = String(class_data.get("display_name", ""))
     definition.description = String(class_data.get("lore", ""))
+    definition.class_tags.clear()
+    var ability_tags := class_data.get("ability_tags", [])
+    if typeof(ability_tags) == TYPE_ARRAY:
+        for tag in ability_tags:
+            if typeof(tag) == TYPE_STRING_NAME:
+                definition.class_tags.append(tag)
+            elif typeof(tag) == TYPE_STRING:
+                definition.class_tags.append(StringName(tag))
 
     var base_stats := class_data.get("base_stats", {})
     if typeof(base_stats) == TYPE_DICTIONARY:

--- a/scripts/hazards/charged_field.gd
+++ b/scripts/hazards/charged_field.gd
@@ -1,0 +1,158 @@
+extends Area2D
+class_name ChargedField
+
+signal player_forced(player: PlayerAvatar, mode: StringName, strength: float)
+signal player_bypassed(player: PlayerAvatar)
+
+@export var field_strength: float = 240.0
+@export var falloff_radius: float = 240.0
+@export_enum("charge_based", "neutral") var default_mode: String = "charge_based"
+@export var attract_positive_charge: bool = false
+@export var attract_negative_charge: bool = true
+
+@export_group("Tag Driven Behaviour")
+## Array of dictionaries. Each entry supports the keys:
+##   tags: Array[StringName] required
+##   mode: "attract", "repel", "neutral", or "bypass"
+##   force_multiplier: Float multiplier applied to the base strength
+@export var tag_force_rules: Array[Dictionary] = [
+    {
+        "tags": [StringName("electric_tricks")],
+        "mode": "attract",
+        "force_multiplier": 1.15,
+    },
+    {
+        "tags": [StringName("magnetic_control")],
+        "mode": "repel",
+        "force_multiplier": 1.0,
+    },
+]
+
+@export_group("Bypass Rules")
+## Array of dictionaries. Each entry supports the keys:
+##   tags: Array[StringName]
+##   reason: String (optional metadata for designers)
+@export var bypass_rules: Array[Dictionary] = [
+    {
+        "tags": [StringName("phase_shift")],
+        "reason": "Phase-shifted particles bypass the electromagnetic field.",
+    },
+]
+
+var _tracked_players: Array[PlayerAvatar] = []
+var _cached_rules: Dictionary = {}
+
+func _ready() -> void:
+    body_entered.connect(_on_body_entered)
+    body_exited.connect(_on_body_exited)
+
+func _physics_process(delta: float) -> void:
+    if _tracked_players.is_empty():
+        return
+    for player in _tracked_players.duplicate():
+        if not is_instance_valid(player):
+            _tracked_players.erase(player)
+            _cached_rules.erase(player)
+            continue
+        var rule: Dictionary = _cached_rules.get(player, {})
+        if _rule_is_bypass(rule) or _matches_bypass_rules(player):
+            continue
+        var force := _evaluate_force(player, rule)
+        if force == Vector2.ZERO:
+            continue
+        player.velocity += force * delta
+        emit_signal("player_forced", player, StringName(rule.get("mode", _default_mode_key(player))), force.length())
+
+func _on_body_entered(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    var rule := _resolve_rule(player)
+    _cached_rules[player] = rule
+    if _rule_is_bypass(rule) or _matches_bypass_rules(player):
+        emit_signal("player_bypassed", player)
+        return
+    if player not in _tracked_players:
+        _tracked_players.append(player)
+
+func _on_body_exited(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    _tracked_players.erase(player)
+    _cached_rules.erase(player)
+
+func _resolve_rule(player: PlayerAvatar) -> Dictionary:
+    for rule in tag_force_rules:
+        if typeof(rule) != TYPE_DICTIONARY:
+            continue
+        var tags := rule.get("tags", [])
+        if tags.is_empty():
+            continue
+        if player.has_any_class_tag(tags):
+            return rule
+    return {}
+
+func _rule_is_bypass(rule: Dictionary) -> bool:
+    if rule.is_empty():
+        return false
+    var mode := String(rule.get("mode", ""))
+    if mode == "bypass":
+        return true
+    return bool(rule.get("bypass", false))
+
+func _matches_bypass_rules(player: PlayerAvatar) -> bool:
+    for entry in bypass_rules:
+        if typeof(entry) != TYPE_DICTIONARY:
+            continue
+        var tags := entry.get("tags", [])
+        if tags.is_empty():
+            continue
+        if player.has_any_class_tag(tags):
+            return true
+    return false
+
+func _evaluate_force(player: PlayerAvatar, rule: Dictionary) -> Vector2:
+    var to_center := global_position - player.global_position
+    var distance := to_center.length()
+    if distance < 0.01:
+        return Vector2.ZERO
+    var direction := to_center / distance
+    var multiplier := float(rule.get("force_multiplier", 1.0))
+    var mode := String(rule.get("mode", ""))
+    if mode == "attract":
+        return direction * _compute_strength(distance) * multiplier
+    elif mode == "repel":
+        return -direction * _compute_strength(distance) * multiplier
+    elif mode == "neutral":
+        return Vector2.ZERO
+    return _evaluate_default_force(player, direction, distance, multiplier)
+
+func _default_mode_key(player: PlayerAvatar) -> String:
+    var rule := _cached_rules.get(player, {})
+    if typeof(rule) == TYPE_DICTIONARY and rule.has("mode"):
+        return String(rule["mode"])
+    return default_mode
+
+func _evaluate_default_force(player: PlayerAvatar, direction: Vector2, distance: float, multiplier: float) -> Vector2:
+    if default_mode != "charge_based":
+        return Vector2.ZERO
+    var charge := player.charge
+    if abs(charge) <= 0.001:
+        return Vector2.ZERO
+    var attract_direction := direction
+    var is_positive := charge > 0.0
+    if is_positive:
+        if not attract_positive_charge:
+            attract_direction = -direction
+    else:
+        if not attract_negative_charge:
+            attract_direction = -direction
+    var strength := _compute_strength(distance) * multiplier * max(abs(charge), 0.25)
+    return attract_direction * strength
+
+func _compute_strength(distance: float) -> float:
+    if falloff_radius <= 0.0:
+        return field_strength
+    var normalized := clamp(distance / falloff_radius, 0.0, 1.0)
+    return field_strength * (1.0 - normalized)

--- a/scripts/hazards/molecule_crafter.gd
+++ b/scripts/hazards/molecule_crafter.gd
@@ -1,0 +1,170 @@
+extends Area2D
+class_name MoleculeCrafter
+
+signal combo_triggered(player: PlayerAvatar, recipe_id: StringName)
+signal combo_failed(player: PlayerAvatar)
+
+@export var reaction_interval: float = 1.25
+@export var default_profile: Dictionary = {
+    "bonuses": {},
+    "multipliers": {
+        "speed": 0.85,
+        "defense": 0.9,
+    },
+    "keywords": [StringName("unstable_compound")],
+}
+@export var default_duration: float = 1.4
+
+@export_group("Combos")
+## Array of dictionaries. Supported keys:
+##   id: String identifier for the combo
+##   tags: Array[StringName] that must all be present
+##   mode: "buff", "volatile", or "sustain"
+##   profile: Dictionary applied for buff/sustain (optional)
+##   duration: Float duration override
+##   payload: Dictionary damage payload for volatile reactions
+@export var combo_recipes: Array[Dictionary] = [
+    {
+        "id": "photonic_solution",
+        "tags": [StringName("light_control"), StringName("support_inert")],
+        "mode": "buff",
+        "profile": {
+            "bonuses": {
+                "speed": 90.0,
+                "control": 0.4,
+            },
+            "multipliers": {
+                "damage": 1.1,
+            },
+            "keywords": [StringName("coherent_light")],
+        },
+        "duration": 3.5,
+    },
+    {
+        "id": "volatile_slurry",
+        "tags": [StringName("reactive_burst"), StringName("toxicity_mastery")],
+        "mode": "volatile",
+        "payload": {
+            "amount": 16.0,
+            "source": "chemical_burn",
+        },
+    },
+]
+
+@export_group("Bypass Rules")
+@export var bypass_rules: Array[Dictionary] = [
+    {
+        "tags": [StringName("phase_shift")],
+        "reason": "Phased entities cannot bind molecules.",
+    },
+]
+
+var _tracked_players: Dictionary = {}
+
+func _ready() -> void:
+    body_entered.connect(_on_body_entered)
+    body_exited.connect(_on_body_exited)
+
+func _physics_process(delta: float) -> void:
+    for player in _tracked_players.keys().duplicate():
+        var data: Dictionary = _tracked_players[player]
+        if not is_instance_valid(player):
+            _tracked_players.erase(player)
+            continue
+        data["timer"] += delta
+        var interval := float(data.get("interval", reaction_interval))
+        if data["timer"] >= interval:
+            data["timer"] -= interval
+            _process_reaction(player, data)
+
+func _on_body_entered(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    if _matches_bypass_rules(player):
+        emit_signal("combo_failed", player)
+        return
+    var recipe := _resolve_recipe(player)
+    _tracked_players[player] = {
+        "recipe": recipe,
+        "timer": 0.0,
+        "interval": float(recipe.get("interval", reaction_interval)),
+    }
+    _process_reaction(player, _tracked_players[player], true)
+
+func _on_body_exited(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    _tracked_players.erase(body)
+
+func _matches_bypass_rules(player: PlayerAvatar) -> bool:
+    for rule in bypass_rules:
+        if typeof(rule) != TYPE_DICTIONARY:
+            continue
+        var tags := rule.get("tags", [])
+        if tags.is_empty():
+            continue
+        if player.has_any_class_tag(tags):
+            return true
+    return false
+
+func _resolve_recipe(player: PlayerAvatar) -> Dictionary:
+    for recipe in combo_recipes:
+        if typeof(recipe) != TYPE_DICTIONARY:
+            continue
+        var tags := recipe.get("tags", [])
+        if tags.is_empty():
+            continue
+        var matches := true
+        for tag in tags:
+            if not player.has_class_tag(StringName(tag)):
+                matches = false
+                break
+        if matches:
+            return recipe
+    return {
+        "id": "default_mix",
+        "mode": "sustain",
+        "profile": default_profile,
+        "duration": default_duration,
+    }
+
+func _process_reaction(player: PlayerAvatar, data: Dictionary, immediate: bool = false) -> void:
+    if not is_instance_valid(player):
+        return
+    _ = immediate
+    var recipe: Dictionary = data.get("recipe", {})
+    var mode := String(recipe.get("mode", "sustain"))
+    match mode:
+        "buff":
+            var profile := recipe.get("profile", default_profile)
+            var duration := float(recipe.get("duration", default_duration))
+            player.apply_temporary_profile(self, _duplicate_profile(profile), duration)
+            emit_signal("combo_triggered", player, StringName(recipe.get("id", "buff")))
+        "volatile":
+            var payload := recipe.get("payload", {})
+            var damage := float(payload.get("amount", 0.0))
+            if damage > 0.0:
+                var duplicated := payload.duplicate(true)
+                duplicated["amount"] = damage
+                player.apply_self_damage(duplicated)
+            emit_signal("combo_triggered", player, StringName(recipe.get("id", "volatile")))
+        _:
+            var profile := recipe.get("profile", default_profile)
+            var duration := float(recipe.get("duration", default_duration))
+            player.apply_temporary_profile(self, _duplicate_profile(profile), duration)
+            emit_signal("combo_triggered", player, StringName(recipe.get("id", "sustain")))
+
+func _duplicate_profile(profile: Dictionary) -> Dictionary:
+    var result := {
+        "bonuses": {},
+        "multipliers": {},
+        "keywords": [],
+    }
+    if profile.has("bonuses"):
+        result["bonuses"] = profile["bonuses"].duplicate(true)
+    if profile.has("multipliers"):
+        result["multipliers"] = profile["multipliers"].duplicate(true)
+    if profile.has("keywords"):
+        result["keywords"] = profile["keywords"].duplicate()
+    return result

--- a/scripts/hazards/nuclear_reactor.gd
+++ b/scripts/hazards/nuclear_reactor.gd
@@ -1,0 +1,171 @@
+extends Area2D
+class_name NuclearReactor
+
+signal meltdown_started(current_heat: float)
+signal meltdown_stabilized(current_heat: float)
+signal reaction_tick(player: PlayerAvatar, reaction_type: StringName, current_heat: float)
+
+@export var ambient_heat_rate: float = 0.35
+@export var heat_decay_rate: float = 0.25
+@export var meltdown_threshold: float = 10.0
+@export var meltdown_burst_damage: float = 32.0
+@export var tick_interval: float = 1.0
+
+@export_group("Tag Channels")
+@export var fusion_tags: Array[StringName] = [
+    StringName("support_reactor"),
+    StringName("fusion_specialist"),
+]
+@export var fission_tags: Array[StringName] = [
+    StringName("radiation_aoe"),
+    StringName("unstable_decay"),
+]
+
+@export_group("Reaction Effects")
+@export var fusion_cooling: float = 2.5
+@export var fission_heat: float = 1.75
+@export var fusion_profile: Dictionary = {
+    "bonuses": {
+        "shield": 35.0,
+    },
+    "multipliers": {
+        "damage": 1.15,
+    },
+    "keywords": [StringName("reactor_synergy")],
+}
+@export var fusion_duration: float = 2.0
+@export var fission_payload: Dictionary = {
+    "amount": 14.0,
+    "source": "reactor_fission",
+}
+
+@export_group("Bypass Rules")
+@export var bypass_rules: Array[Dictionary] = [
+    {
+        "tags": [StringName("phase_shift")],
+        "reason": "Intangible forms slip through the reactor core.",
+    },
+]
+
+var _heat: float = 0.0
+var _meltdown: bool = false
+var _tracked_players: Dictionary = {}
+
+func _ready() -> void:
+    body_entered.connect(_on_body_entered)
+    body_exited.connect(_on_body_exited)
+
+func _physics_process(delta: float) -> void:
+    if _tracked_players.is_empty():
+        _heat = max(_heat - heat_decay_rate * delta, 0.0)
+    else:
+        _heat = max(_heat - heat_decay_rate * delta, 0.0)
+        _heat += ambient_heat_rate * delta
+    for player in _tracked_players.keys().duplicate():
+        var data: Dictionary = _tracked_players[player]
+        if not is_instance_valid(player):
+            _tracked_players.erase(player)
+            continue
+        data["timer"] += delta
+        if data["timer"] >= data.get("interval", tick_interval):
+            data["timer"] -= data.get("interval", tick_interval)
+            _apply_reaction(player, data)
+    if _heat >= meltdown_threshold and not _meltdown:
+        _meltdown = true
+        emit_signal("meltdown_started", _heat)
+        _trigger_meltdown_burst()
+    elif _meltdown and _heat < meltdown_threshold * 0.25:
+        _meltdown = false
+        emit_signal("meltdown_stabilized", _heat)
+
+func _on_body_entered(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    var player := body as PlayerAvatar
+    if _matches_bypass_rules(player):
+        emit_signal("reaction_tick", player, StringName("bypass"), _heat)
+        return
+    var mode := _resolve_mode(player)
+    if mode == "bypass":
+        emit_signal("reaction_tick", player, StringName("bypass"), _heat)
+        return
+    _tracked_players[player] = {
+        "mode": mode,
+        "timer": 0.0,
+        "interval": tick_interval,
+    }
+    _apply_reaction(player, _tracked_players[player], true)
+
+func _on_body_exited(body: Node) -> void:
+    if not (body is PlayerAvatar):
+        return
+    _tracked_players.erase(body)
+
+func _resolve_mode(player: PlayerAvatar) -> String:
+    if player.has_any_class_tag(fusion_tags):
+        return "fusion"
+    if player.has_any_class_tag(fission_tags):
+        return "fission"
+    return "neutral"
+
+func _matches_bypass_rules(player: PlayerAvatar) -> bool:
+    for rule in bypass_rules:
+        if typeof(rule) != TYPE_DICTIONARY:
+            continue
+        var tags := rule.get("tags", [])
+        if tags.is_empty():
+            continue
+        if player.has_any_class_tag(tags):
+            return true
+    return false
+
+func _apply_reaction(player: PlayerAvatar, data: Dictionary, immediate: bool = false) -> void:
+    if not is_instance_valid(player):
+        return
+    _ = immediate
+    var mode := String(data.get("mode", "neutral"))
+    match mode:
+        "fusion":
+            _heat = max(_heat - fusion_cooling, 0.0)
+            player.apply_temporary_profile(self, _duplicate_profile(fusion_profile), fusion_duration)
+        "fission":
+            _heat += fission_heat
+            var payload := fission_payload.duplicate(true)
+            payload["amount"] = float(payload.get("amount", 0.0))
+            if payload["amount"] > 0.0:
+                player.apply_self_damage(payload)
+        _:
+            if _meltdown:
+                var payload := {
+                    "amount": meltdown_burst_damage * 0.5,
+                    "source": "reactor_meltdown",
+                }
+                player.apply_self_damage(payload)
+    emit_signal("reaction_tick", player, StringName(mode), _heat)
+    if _meltdown and mode != "fusion":
+        _trigger_meltdown_burst()
+
+func _trigger_meltdown_burst() -> void:
+    for player in _tracked_players.keys().duplicate():
+        if not is_instance_valid(player):
+            _tracked_players.erase(player)
+            continue
+        var payload := {
+            "amount": meltdown_burst_damage,
+            "source": "reactor_meltdown",
+        }
+        player.apply_self_damage(payload)
+
+func _duplicate_profile(profile: Dictionary) -> Dictionary:
+    var result := {
+        "bonuses": {},
+        "multipliers": {},
+        "keywords": [],
+    }
+    if profile.has("bonuses"):
+        result["bonuses"] = profile["bonuses"].duplicate(true)
+    if profile.has("multipliers"):
+        result["multipliers"] = profile["multipliers"].duplicate(true)
+    if profile.has("keywords"):
+        result["keywords"] = profile["keywords"].duplicate()
+    return result

--- a/scripts/player/player_avatar.gd
+++ b/scripts/player/player_avatar.gd
@@ -29,6 +29,7 @@ var current_keywords: Array[StringName] = []
 var mass: float = 1.0
 var charge: float = 0.0
 var stability: float = 1.0
+var class_tags: Array[StringName] = []
 
 var resource_pools: Dictionary = {}
 var status_manager: StatusManager = null
@@ -60,6 +61,12 @@ func set_particle_class(value: ParticleClassDefinition) -> void:
         mass = particle_class.mass
         charge = particle_class.charge
         stability = particle_class.stability
+        class_tags.clear()
+        for tag in particle_class.class_tags:
+            if typeof(tag) == TYPE_STRING_NAME:
+                class_tags.append(tag)
+            else:
+                class_tags.append(StringName(tag))
         _initialize_resources()
         var loadout := particle_class.create_loadout()
         for slot in loadout:
@@ -68,6 +75,7 @@ func set_particle_class(value: ParticleClassDefinition) -> void:
         mass = 1.0
         charge = 0.0
         stability = 1.0
+        class_tags.clear()
         _initialize_resources()
     _update_instability_factor()
     _update_status_immunities()
@@ -268,6 +276,19 @@ func get_stat(stat: StringName) -> float:
 
 func has_keyword(keyword: StringName) -> bool:
     return keyword in current_keywords
+
+func has_class_tag(tag: StringName) -> bool:
+    tag = StringName(tag)
+    return tag in class_tags
+
+func has_any_class_tag(tags: Array) -> bool:
+    for tag in tags:
+        if has_class_tag(StringName(tag)):
+            return true
+    return false
+
+func get_class_tags() -> Array[StringName]:
+    return class_tags.duplicate()
 
 func _ensure_status_manager() -> void:
     if status_manager:


### PR DESCRIPTION
## Summary
- add class tag metadata to particle class definitions and propagate it onto player avatars
- create charged field, nuclear reactor, and molecule crafter hazard scripts with configurable tag-driven behaviour and bypass rules
- build electromagnetism, nuclear lab, and chemistry lab level scenes that compose the new modular hazard scenes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1ba63cdbc8329a4310f7904df1526