### PR TITLE
Resolve autoload naming conflicts in Godot project

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -13,7 +13,7 @@ run/main_scene="res://scenes/levels/LevelRoot.tscn"
 
 RunRNG="*res://scripts/systems/RunRNG.gd"
 GameState="*res://scripts/systems/GameState.gd"
-InputMap="*res://scripts/systems/InputMap.gd"
+InputBindings="*res://scripts/systems/InputBindings.gd"
 
 [display]
 

--- a/godot/scripts/systems/InputBindings.gd
+++ b/godot/scripts/systems/InputBindings.gd
@@ -30,7 +30,7 @@ var DEFAULT_ACTIONS := {
 
 func _ready() -> void:
     if _engine_input_map == null:
-        push_warning("InputMap autoload: Engine InputMap singleton is unavailable.")
+        push_warning("InputBindings autoload: Engine InputMap singleton is unavailable.")
         return
     apply_default_bindings()
 
@@ -50,8 +50,8 @@ func register_custom_action(action_name: StringName, events: Array) -> void:
     if _engine_input_map == null:
         return
     reset_action(action_name)
-    for event in events:
-        _engine_input_map.action_add_event(action_name, event)
+    for input_event in events:
+        _engine_input_map.action_add_event(action_name, input_event)
 
 func _register_action(action_name: StringName, definition: Dictionary) -> void:
     if _engine_input_map == null:
@@ -66,10 +66,10 @@ func _register_action(action_name: StringName, definition: Dictionary) -> void:
         button_event.button_index = int(button)
         _engine_input_map.action_add_event(action_name, button_event)
     for axis_data in definition.get("joypad_axes", []):
-        var axis_event := InputEventJoypadMotion.new()
-        axis_event.axis = int(axis_data.get("axis", JOY_AXIS_LEFT_X))
-        axis_event.axis_value = float(axis_data.get("value", 0.0))
-        _engine_input_map.action_add_event(action_name, axis_event)
+        var motion_event := InputEventJoypadMotion.new()
+        motion_event.axis = int(axis_data.get("axis", JOY_AXIS_LEFT_X))
+        motion_event.axis_value = float(axis_data.get("value", 0.0))
+        _engine_input_map.action_add_event(action_name, motion_event)
 
 func get_action_events(action_name: StringName) -> Array:
     if _engine_input_map == null:

--- a/godot/scripts/systems/RunRNG.gd
+++ b/godot/scripts/systems/RunRNG.gd
@@ -10,8 +10,8 @@ func _ready() -> void:
 func randomize() -> void:
     set_seed(generate_seed_from_time())
 
-func set_seed(seed: int) -> void:
-    _seed = int(abs(seed))
+func set_seed(seed_value: int) -> void:
+    _seed = int(abs(seed_value))
     if _seed == 0:
         _seed = 1
     _rng.seed = _seed
@@ -47,13 +47,13 @@ func get_state() -> Dictionary:
         "state": _rng.state,
     }
 
-func set_state(state: Dictionary) -> void:
-    if state.is_empty():
+func set_state(state_data: Dictionary) -> void:
+    if state_data.is_empty():
         return
-    _seed = int(abs(state.get("seed", _seed)))
+    _seed = int(abs(state_data.get("seed", _seed)))
     if _seed == 0:
         _seed = 1
     _rng.seed = _seed
-    var rng_state = state.get("state")
+    var rng_state = state_data.get("state")
     if rng_state != null:
         _rng.state = rng_state


### PR DESCRIPTION
## Summary
- rename the custom InputMap autoload to InputBindings to avoid conflicts with Godot's built-in singleton and adjust its helper script
- rename RunRNG parameter names to avoid clashes with built-in functions
- update project autoload configuration to reference the new InputBindings autoload

## Testing
- not run (environment only supports static analysis)


------
https://chatgpt.com/codex/tasks/task_e_68e1823dea388329ab3d7ce08c85e1d0