### PR TITLE
Refine default input binding seeding

### DIFF
--- a/godot/scripts/systems/InputBindings.gd
+++ b/godot/scripts/systems/InputBindings.gd
@@ -1,5 +1,6 @@
 extends Node
-var DEFAULT_ACTIONS := {
+
+const DEFAULT_ACTIONS := {
 	&"move_left": {
 		"keys": [Key.KEY_A, Key.KEY_LEFT],
 		"joypad_axes": [{"axis": JOY_AXIS_LEFT_X, "value": -1.0}],
@@ -30,26 +31,23 @@ func _ready() -> void:
 	apply_default_bindings()
 
 func apply_default_bindings() -> void:
-	for action_name in DEFAULT_ACTIONS.keys():
-		_register_action(action_name, DEFAULT_ACTIONS[action_name])
+        for action_name: StringName in DEFAULT_ACTIONS.keys():
+                _apply_action_definition(action_name, DEFAULT_ACTIONS[action_name])
 
 func reset_action(action_name: StringName) -> void:
-	if InputMap.has_action(action_name):
-		InputMap.action_erase_events(action_name)
-	else:
-		InputMap.add_action(action_name)
+        _prepare_action(action_name)
 
 func register_custom_action(action_name: StringName, events: Array) -> void:
-	reset_action(action_name)
-	for input_event in events:
-		InputMap.action_add_event(action_name, input_event)
+        _prepare_action(action_name)
+        for input_event in events:
+                InputMap.action_add_event(action_name, input_event)
 
-func _register_action(action_name: StringName, definition: Dictionary) -> void:
-	reset_action(action_name)
-	for keycode in definition.get("keys", []):
-		var key_event := InputEventKey.new()
-		key_event.physical_keycode = int(keycode)
-		InputMap.action_add_event(action_name, key_event)
+func _apply_action_definition(action_name: StringName, definition: Dictionary) -> void:
+        _prepare_action(action_name)
+        for keycode in definition.get("keys", []):
+                var key_event := InputEventKey.new()
+                key_event.physical_keycode = int(keycode)
+                InputMap.action_add_event(action_name, key_event)
 	for button in definition.get("joypad_buttons", []):
 		var button_event := InputEventJoypadButton.new()
 		button_event.button_index = int(button)
@@ -61,10 +59,17 @@ func _register_action(action_name: StringName, definition: Dictionary) -> void:
 		InputMap.action_add_event(action_name, motion_event)
 
 func get_action_events(action_name: StringName) -> Array:
-	if not InputMap.has_action(action_name):
-		return []
-	return InputMap.action_get_events(action_name)
+        ensure_action(action_name)
+        return InputMap.action_get_events(action_name)
 
 func ensure_action(action_name: StringName) -> void:
-	if not InputMap.has_action(action_name):
-		InputMap.add_action(action_name)
+        if not InputMap.has_action(action_name):
+                InputMap.add_action(action_name)
+
+func _prepare_action(action_name: StringName) -> void:
+        _clear_or_create_action(action_name)
+        InputMap.action_erase_events(action_name)
+
+func _clear_or_create_action(action_name: StringName) -> void:
+        if not InputMap.has_action(action_name):
+                InputMap.add_action(action_name)


### PR DESCRIPTION
## Summary
- seed default bindings directly through the global InputMap API without cached engine handles
- ensure default and custom actions always prepare their InputMap entries before attaching events

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1ddc522908329b2a89a5f609b69e9