### PR TITLE
Clean up InputMap metadata after relocating assets

### DIFF
--- a/godot/.godot/editor/project_metadata.cfg
+++ b/godot/.godot/editor/project_metadata.cfg
@@ -13,7 +13,7 @@ use_advanced_connections=false
 [recent_files]
 
 scenes=["res://scenes/levels/LevelRoot.tscn"]
-scripts=["res://scripts/player/player_avatar.gd", "TileMap", "res://scripts/systems/InputBindings.gd", "res://scripts/systems/GameState.gd", "res://scripts/systems/RunRNG.gd", "res://scripts/systems/InputMap.gd"]
+scripts=["res://scripts/player/player_avatar.gd", "TileMap", "res://scripts/systems/InputBindings.gd", "res://scripts/systems/GameState.gd", "res://scripts/systems/RunRNG.gd"]
 
 [linked_properties]
 

--- a/godot/scripts/systems/InputMap.gd.uid
+++ b/godot/scripts/systems/InputMap.gd.uid
@@ -1,1 +1,0 @@
-uid://bhwhrmhomet36


### PR DESCRIPTION
## Summary
- remove the stale `InputMap.gd` UID file so the editor stops tracking a script that no longer exists after consolidating assets under `godot/`
- refresh the Godot editor recent-files list to include only scripts that resolve under `res://scripts`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1deaa22708329881103e8faecd7db