### PR TITLE
Set up LevelRoot prototype scene

### DIFF
--- a/godot/scenes/levels/LevelRoot.tscn
+++ b/godot/scenes/levels/LevelRoot.tscn
@@ -1,10 +1,13 @@
-[gd_scene load_steps=6 format=3]
+[gd_scene load_steps=9 format=3]
 
 [ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
 [ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="2"]
 [ext_resource type="PackedScene" path="res://scenes/levels/electromagnetism_lab.tscn" id="3"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/chemical_vat.tscn" id="4"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/magnetic_trap.tscn" id="5"]
+[ext_resource type="PackedScene" path="res://scenes/levels/chemistry_lab.tscn" id="6"]
+[ext_resource type="PackedScene" path="res://scenes/levels/nuclear_lab.tscn" id="7"]
+[ext_resource type="PackedScene" path="res://scenes/hazards/radiation_zone.tscn" id="8"]
 
 [sub_resource type="TileSet" id="TileSet_d2p3q"]
 tile_size = Vector2i(64, 64)
@@ -21,6 +24,7 @@ unique_name_in_owner = true
 position = Vector2(0, -32)
 
 [node name="Player" parent="." instance=ExtResource("1")]
+unique_name_in_owner = true
 position = Vector2(0, -32)
 
 [node name="Camera2D" type="Camera2D" parent="Player"]
@@ -30,23 +34,39 @@ limit_left = -4096
 limit_right = 4096
 limit_top = -4096
 current = true
+position_smoothing_enabled = true
+position_smoothing_speed = 6.0
 
-[node name="GameController" type="Node" parent="."]
+[node name="GameController" type="CanvasLayer" parent="."]
+unique_name_in_owner = true
 script = ExtResource("2")
 player_path = NodePath("../Player")
 
-[node name="Hazards" type="Node2D" parent="."]
+[node name="StageContent" type="Node2D" parent="."]
+unique_name_in_owner = true
+
+[node name="ElectromagnetismLab" parent="StageContent" instance=ExtResource("3")]
+
+[node name="ChemistryLab" parent="StageContent" instance=ExtResource("6")]
+position = Vector2(920, -40)
+
+[node name="NuclearLab" parent="StageContent" instance=ExtResource("7")]
+position = Vector2(-920, 0)
+
+[node name="Hazards" type="Node2D" parent="StageContent"]
 unique_name_in_owner = true
 groups = ["level_hazards"]
 
-[node name="ElectromagnetismLab" parent="Hazards" instance=ExtResource("3")]
-
 [node name="ChemicalVat" parent="Hazards" instance=ExtResource("4")]
-position = Vector2(-320, 192)
+position = Vector2(-520, 240)
 
 [node name="MagneticTrap" parent="Hazards" instance=ExtResource("5")]
-position = Vector2(320, 192)
+position = Vector2(520, 240)
 
-[node name="Interactives" type="Node2D" parent="."]
+[node name="RadiationZone" parent="Hazards" instance=ExtResource("8")]
+position = Vector2(0, 320)
+
+[node name="Interactives" type="Node2D" parent="StageContent"]
 unique_name_in_owner = true
 groups = ["level_interactives"]
+


### PR DESCRIPTION
## Summary
- instance the player avatar, camera, and game controller in `LevelRoot.tscn`
- add prototype stage content including laboratory and hazard scenes for testing
- organize the level hierarchy so gameplay and UI bootstrap correctly with the controller referencing the player

## Testing
- Not run (Godot editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1e2501cb48329ba2a23038c6c11ad