### PR TITLE
Simplify InputMap handling in InputBindings

### DIFF
--- a/godot/scripts/systems/InputBindings.gd
+++ b/godot/scripts/systems/InputBindings.gd
@@ -67,9 +67,5 @@ func ensure_action(action_name: StringName) -> void:
                 InputMap.add_action(action_name)
 
 func _prepare_action(action_name: StringName) -> void:
-        _clear_or_create_action(action_name)
+        ensure_action(action_name)
         InputMap.action_erase_events(action_name)
-
-func _clear_or_create_action(action_name: StringName) -> void:
-        if not InputMap.has_action(action_name):
-                InputMap.add_action(action_name)


### PR DESCRIPTION
## Summary
- simplify InputBindings so action preparation reuses ensure_action and the InputMap singleton directly
- remove the redundant helper that wrapped InputMap availability checks

## Testing
- not run (Godot CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1f7a868ac832986297da4863299b3