### PR TITLE
Add script UIDs to relocated Godot assets

### DIFF
--- a/godot/data/classes/elements/alkali.tres
+++ b/godot/data/classes/elements/alkali.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
 
-[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1" uid="uid://b1roasqjk2lpy"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/elements/alkaline_earth.tres
+++ b/godot/data/classes/elements/alkaline_earth.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
 
-[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1" uid="uid://b1roasqjk2lpy"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/elements/chalcogen.tres
+++ b/godot/data/classes/elements/chalcogen.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
 
-[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1" uid="uid://b1roasqjk2lpy"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/elements/halogen.tres
+++ b/godot/data/classes/elements/halogen.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
 
-[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1" uid="uid://b1roasqjk2lpy"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/elements/noble_gas.tres
+++ b/godot/data/classes/elements/noble_gas.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
 
-[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1" uid="uid://b1roasqjk2lpy"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/elements/radioactive.tres
+++ b/godot/data/classes/elements/radioactive.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
 
-[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1" uid="uid://b1roasqjk2lpy"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/elements/transition.tres
+++ b/godot/data/classes/elements/transition.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ParticleClass" load_steps=2]
 
-[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/resources/particle_class.gd" id="1" uid="uid://b1roasqjk2lpy"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/particles/down_quark.tres
+++ b/godot/data/classes/particles/down_quark.tres
@@ -1,9 +1,9 @@
 [gd_resource type="Resource" load_steps=5 format=3]
 
-[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/abilities/downward_smash.gd" id="2"]
-[ext_resource type="Script" path="res://scripts/abilities/mass_anchor.gd" id="3"]
-[ext_resource type="Script" path="res://scripts/abilities/baryon_wall.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1" uid="uid://d3u3gp8i1aw2r"]
+[ext_resource type="Script" path="res://scripts/abilities/downward_smash.gd" id="2" uid="uid://cs7gryu0vd5g6"]
+[ext_resource type="Script" path="res://scripts/abilities/mass_anchor.gd" id="3" uid="uid://ph2cttevxdcu"]
+[ext_resource type="Script" path="res://scripts/abilities/baryon_wall.gd" id="4" uid="uid://dydq4yw3puoj0"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/particles/electron.tres
+++ b/godot/data/classes/particles/electron.tres
@@ -1,9 +1,9 @@
 [gd_resource type="Resource" load_steps=5 format=3]
 
-[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/abilities/orbital_strike.gd" id="2"]
-[ext_resource type="Script" path="res://scripts/abilities/ion_field.gd" id="3"]
-[ext_resource type="Script" path="res://scripts/abilities/chain_discharge.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1" uid="uid://d3u3gp8i1aw2r"]
+[ext_resource type="Script" path="res://scripts/abilities/orbital_strike.gd" id="2" uid="uid://b8471e032hbg7"]
+[ext_resource type="Script" path="res://scripts/abilities/ion_field.gd" id="3" uid="uid://clpf76j5y4jw4"]
+[ext_resource type="Script" path="res://scripts/abilities/chain_discharge.gd" id="4" uid="uid://dy5hsg0n8tkuc"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/particles/electron_neutrino.tres
+++ b/godot/data/classes/particles/electron_neutrino.tres
@@ -1,9 +1,9 @@
 [gd_resource type="Resource" load_steps=5 format=3]
 
-[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/abilities/phase_shift.gd" id="2"]
-[ext_resource type="Script" path="res://scripts/abilities/ghost_walk.gd" id="3"]
-[ext_resource type="Script" path="res://scripts/abilities/weak_flux.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1" uid="uid://d3u3gp8i1aw2r"]
+[ext_resource type="Script" path="res://scripts/abilities/phase_shift.gd" id="2" uid="uid://dhsnr50xunftc"]
+[ext_resource type="Script" path="res://scripts/abilities/ghost_walk.gd" id="3" uid="uid://xub1qcd57yyn"]
+[ext_resource type="Script" path="res://scripts/abilities/weak_flux.gd" id="4" uid="uid://8k1rsd45ae3l"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/particles/gluon.tres
+++ b/godot/data/classes/particles/gluon.tres
@@ -1,9 +1,9 @@
 [gd_resource type="Resource" load_steps=5 format=3]
 
-[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/abilities/gluon_bind.gd" id="2"]
-[ext_resource type="Script" path="res://scripts/abilities/color_field.gd" id="3"]
-[ext_resource type="Script" path="res://scripts/abilities/fusion_lock.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1" uid="uid://d3u3gp8i1aw2r"]
+[ext_resource type="Script" path="res://scripts/abilities/gluon_bind.gd" id="2" uid="uid://c6s5k2sqqbxcl"]
+[ext_resource type="Script" path="res://scripts/abilities/color_field.gd" id="3" uid="uid://cyh18qcpyqjxi"]
+[ext_resource type="Script" path="res://scripts/abilities/fusion_lock.gd" id="4" uid="uid://dlrpk1bex26fj"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/particles/higgs_boson.tres
+++ b/godot/data/classes/particles/higgs_boson.tres
@@ -1,9 +1,9 @@
 [gd_resource type="Resource" load_steps=5 format=3]
 
-[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/abilities/higgs_mass_boost.gd" id="2"]
-[ext_resource type="Script" path="res://scripts/abilities/inertial_field.gd" id="3"]
-[ext_resource type="Script" path="res://scripts/abilities/higgs_resonance.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1" uid="uid://d3u3gp8i1aw2r"]
+[ext_resource type="Script" path="res://scripts/abilities/higgs_mass_boost.gd" id="2" uid="uid://dh8cxupu4x1tc"]
+[ext_resource type="Script" path="res://scripts/abilities/inertial_field.gd" id="3" uid="uid://b4trxsqd4ncrm"]
+[ext_resource type="Script" path="res://scripts/abilities/higgs_resonance.gd" id="4" uid="uid://cxdw7tqwsnrv3"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/particles/photon.tres
+++ b/godot/data/classes/particles/photon.tres
@@ -1,9 +1,9 @@
 [gd_resource type="Resource" load_steps=5 format=3]
 
-[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/abilities/photon_pulse.gd" id="2"]
-[ext_resource type="Script" path="res://scripts/abilities/refraction_cloak.gd" id="3"]
-[ext_resource type="Script" path="res://scripts/abilities/gamma_burst.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1" uid="uid://d3u3gp8i1aw2r"]
+[ext_resource type="Script" path="res://scripts/abilities/photon_pulse.gd" id="2" uid="uid://2cqdbyfhdoi2"]
+[ext_resource type="Script" path="res://scripts/abilities/refraction_cloak.gd" id="3" uid="uid://6jsiu5ylgm8h"]
+[ext_resource type="Script" path="res://scripts/abilities/gamma_burst.gd" id="4" uid="uid://cbsxpm61vmcif"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/particles/up_quark.tres
+++ b/godot/data/classes/particles/up_quark.tres
@@ -1,9 +1,9 @@
 [gd_resource type="Resource" load_steps=5 format=3]
 
-[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/abilities/color_dash.gd" id="2"]
-[ext_resource type="Script" path="res://scripts/abilities/fractional_charge.gd" id="3"]
-[ext_resource type="Script" path="res://scripts/abilities/hadronize.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1" uid="uid://d3u3gp8i1aw2r"]
+[ext_resource type="Script" path="res://scripts/abilities/color_dash.gd" id="2" uid="uid://q8r36f6qvg3i"]
+[ext_resource type="Script" path="res://scripts/abilities/fractional_charge.gd" id="3" uid="uid://bp4tsr5mlpf4h"]
+[ext_resource type="Script" path="res://scripts/abilities/hadronize.gd" id="4" uid="uid://cmvgrjs85t3gf"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/particles/w_boson.tres
+++ b/godot/data/classes/particles/w_boson.tres
@@ -1,9 +1,9 @@
 [gd_resource type="Resource" load_steps=5 format=3]
 
-[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/abilities/w_blast.gd" id="2"]
-[ext_resource type="Script" path="res://scripts/abilities/weak_charge_field.gd" id="3"]
-[ext_resource type="Script" path="res://scripts/abilities/beta_decay.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1" uid="uid://d3u3gp8i1aw2r"]
+[ext_resource type="Script" path="res://scripts/abilities/w_blast.gd" id="2" uid="uid://bhoqxfobl6dh5"]
+[ext_resource type="Script" path="res://scripts/abilities/weak_charge_field.gd" id="3" uid="uid://c007241g2r0nw"]
+[ext_resource type="Script" path="res://scripts/abilities/beta_decay.gd" id="4" uid="uid://n1dih561d034"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/data/classes/particles/z_boson.tres
+++ b/godot/data/classes/particles/z_boson.tres
@@ -1,9 +1,9 @@
 [gd_resource type="Resource" load_steps=5 format=3]
 
-[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1"]
-[ext_resource type="Script" path="res://scripts/abilities/z_pulse.gd" id="2"]
-[ext_resource type="Script" path="res://scripts/abilities/neutral_screen.gd" id="3"]
-[ext_resource type="Script" path="res://scripts/abilities/annihilation_wave.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/classes/particle_class.gd" id="1" uid="uid://d3u3gp8i1aw2r"]
+[ext_resource type="Script" path="res://scripts/abilities/z_pulse.gd" id="2" uid="uid://bw6lknx7uack3"]
+[ext_resource type="Script" path="res://scripts/abilities/neutral_screen.gd" id="3" uid="uid://dv7swwx1w11ep"]
+[ext_resource type="Script" path="res://scripts/abilities/annihilation_wave.gd" id="4" uid="uid://ia1gmlavgohk"]
 
 [resource]
 script = ExtResource("1")

--- a/godot/scenes/hazards/charged_field.tscn
+++ b/godot/scenes/hazards/charged_field.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3]
 
-[ext_resource type="Script" path="res://scripts/hazards/charged_field.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/hazards/charged_field.gd" id="1" uid="uid://cclnnjikx4mpt"]
 
 [sub_resource type="CircleShape2D" id="1"]
 radius = 260.0

--- a/godot/scenes/hazards/chemical_vat.tscn
+++ b/godot/scenes/hazards/chemical_vat.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3]
 
-[ext_resource type="Script" path="res://scripts/hazards/chemical_vat.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/hazards/chemical_vat.gd" id="1" uid="uid://bp70eqxbged0s"]
 
 [sub_resource type="RectangleShape2D" id="1"]
 extents = Vector2(140, 120)

--- a/godot/scenes/hazards/electric_field.tscn
+++ b/godot/scenes/hazards/electric_field.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3]
 
-[ext_resource type="Script" path="res://scripts/hazards/electromagnetic_field.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/hazards/electromagnetic_field.gd" id="1" uid="uid://di5icyfrxm5b5"]
 
 [sub_resource type="CircleShape2D" id="1"]
 radius = 120.0

--- a/godot/scenes/hazards/magnetic_trap.tscn
+++ b/godot/scenes/hazards/magnetic_trap.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3]
 
-[ext_resource type="Script" path="res://scripts/hazards/magnetic_trap.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/hazards/magnetic_trap.gd" id="1" uid="uid://wnq2vd47vono"]
 
 [sub_resource type="RectangleShape2D" id="1"]
 extents = Vector2(160, 160)

--- a/godot/scenes/hazards/molecule_crafter.tscn
+++ b/godot/scenes/hazards/molecule_crafter.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3]
 
-[ext_resource type="Script" path="res://scripts/hazards/molecule_crafter.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/hazards/molecule_crafter.gd" id="1" uid="uid://dccc8hyo6x20j"]
 
 [sub_resource type="CircleShape2D" id="1"]
 radius = 180.0

--- a/godot/scenes/hazards/nuclear_reactor.tscn
+++ b/godot/scenes/hazards/nuclear_reactor.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3]
 
-[ext_resource type="Script" path="res://scripts/hazards/nuclear_reactor.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/hazards/nuclear_reactor.gd" id="1" uid="uid://crnblvjgogo41"]
 
 [sub_resource type="CircleShape2D" id="1"]
 radius = 200.0

--- a/godot/scenes/hazards/radiation_zone.tscn
+++ b/godot/scenes/hazards/radiation_zone.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3]
 
-[ext_resource type="Script" path="res://scripts/hazards/radiation_zone.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/hazards/radiation_zone.gd" id="1" uid="uid://dr1t3d6p7l30b"]
 
 [sub_resource type="CircleShape2D" id="1"]
 radius = 180.0

--- a/godot/scenes/levels/LevelRoot.tscn
+++ b/godot/scenes/levels/LevelRoot.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=11 format=3]
 
 [ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
-[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="2"]
+[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="2" uid="uid://bryr478pcwtbl"]
 [ext_resource type="PackedScene" path="res://scenes/levels/electromagnetism_lab.tscn" id="3"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/chemical_vat.tscn" id="4"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/magnetic_trap.tscn" id="5"]

--- a/godot/scenes/levels/chemical_vat_prototype.tscn
+++ b/godot/scenes/levels/chemical_vat_prototype.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/chemical_vat.tscn" id="2"]
-[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="3" uid="uid://bryr478pcwtbl"]
 
 [node name="ChemicalVatPrototype" type="Node2D"]
 

--- a/godot/scenes/levels/electric_field_prototype.tscn
+++ b/godot/scenes/levels/electric_field_prototype.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/electric_field.tscn" id="2"]
-[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="3"]
+[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="3" uid="uid://bryr478pcwtbl"]
 
 [node name="ElectricFieldPrototype" type="Node2D"]
 

--- a/godot/scenes/levels/magnetic_trap_prototype.tscn
+++ b/godot/scenes/levels/magnetic_trap_prototype.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/magnetic_trap.tscn" id="2"]
 [ext_resource type="Resource" path="res://data/classes/particles/down_quark.tres" id="3"]
-[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="4" uid="uid://bryr478pcwtbl"]
 
 [node name="MagneticTrapPrototype" type="Node2D"]
 

--- a/godot/scenes/levels/radiation_zone_prototype.tscn
+++ b/godot/scenes/levels/radiation_zone_prototype.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="PackedScene" path="res://scenes/player/player_avatar.tscn" id="1"]
 [ext_resource type="PackedScene" path="res://scenes/hazards/radiation_zone.tscn" id="2"]
 [ext_resource type="Resource" path="res://data/classes/particles/electron_neutrino.tres" id="3"]
-[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="4"]
+[ext_resource type="Script" path="res://scripts/game/game_controller.gd" id="4" uid="uid://bryr478pcwtbl"]
 
 [node name="RadiationZonePrototype" type="Node2D"]
 

--- a/godot/scenes/player/player_avatar.tscn
+++ b/godot/scenes/player/player_avatar.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3]
 
-[ext_resource type="Script" path="res://scripts/player/player_avatar.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/player/player_avatar.gd" id="1" uid="uid://dh1mwseojcule"]
 [ext_resource type="Resource" path="res://data/classes/particles/up_quark.tres" id="2"]
 
 [node name="PlayerAvatar" type="CharacterBody2D"]

--- a/godot/scenes/ui/CharacterSelect.tscn
+++ b/godot/scenes/ui/CharacterSelect.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" path="res://scripts/ui/character_select.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/ui/character_select.gd" id="1" uid="uid://cxgw834licujl"]
 
 [node name="CharacterSelect" type="Control"]
 anchor_right = 1.0

--- a/godot/scenes/ui/CodexViewer.tscn
+++ b/godot/scenes/ui/CodexViewer.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3]
 
-[ext_resource type="Script" path="res://scripts/ui/codex_viewer.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/ui/codex_viewer.gd" id="1" uid="uid://dtje67hssf6yn"]
 
 [node name="CodexViewer" type="Control"]
 anchor_right = 1.0


### PR DESCRIPTION
## Summary
- add Godot script UID metadata to scenes and resource files so moved assets resolve under `res://`
- refresh hazard and level prototype scenes to reference the relocated GameController script by UID
- update particle definition `.tres` files to include UIDs for their associated ability and class scripts

## Testing
- not run (Godot editor required)

------
https://chatgpt.com/codex/tasks/task_e_68e2afee3eb88329a9d2e8023c88cf8c