### PR TITLE
Nest HUD under GameController in LevelRoot

### DIFF
--- a/godot/scenes/levels/LevelRoot.tscn
+++ b/godot/scenes/levels/LevelRoot.tscn
@@ -39,12 +39,13 @@ current = true
 position_smoothing_enabled = true
 position_smoothing_speed = 6.0
 
-[node name="GameController" type="CanvasLayer" parent="."]
+[node name="GameController" type="Node" parent="."]
 unique_name_in_owner = true
 script = ExtResource("2")
 player_path = NodePath("../Player")
 
-[node name="RunHUD" parent="." instance=ExtResource("9")]
+[node name="RunHUD" parent="GameController" instance=ExtResource("9")]
+unique_name_in_owner = true
 
 [node name="StageContent" type="Node2D" parent="."]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- convert the LevelRoot GameController to a standard Node so it can manage scene logic
- parent the RunHUD under the controller and give it a unique name for simpler access

## Testing
- not run (Godot editor not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68e2c82862fc8329b48d7ecade818b37