### PR TITLE
Prevent root-level asset directories from reappearing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 # Ignore Godot generated import cache
 /godot/.import/
+
+# Prevent mistakenly placing game content outside the Godot project root
+/data/
+/scenes/
+/scripts/


### PR DESCRIPTION
## Summary
- add top-level ignore rules so scripts, scenes, and data stay inside the Godot project root

## Testing
- `python - <<'PY' ...` (verified all res:// references resolve)

------
https://chatgpt.com/codex/tasks/task_e_68e2ff0eff3c8329b5b0fc9113526491