### PR TITLE
Fix RNG autoload and tidy game state

### DIFF
--- a/godot/scripts/systems/GameState.gd
+++ b/godot/scripts/systems/GameState.gd
@@ -10,42 +10,42 @@ var run_seed: int = 0
 var run_metadata: Dictionary = {}
 
 func _ready() -> void:
-	if not is_run_active:
-		run_seed = RunRNG.generate_seed_from_time()
-		RunRNG.set_seed(run_seed)
-		run_metadata = {}
+    if not is_run_active:
+        run_seed = RunRNG.generate_seed_from_time()
+        RunRNG.set_seed(run_seed)
+        run_metadata = {}
 
 func start_new_run(seed: int = RunRNG.generate_seed_from_time(), metadata: Dictionary = {}) -> void:
-	run_seed = seed
-	run_metadata = metadata.duplicate(true)
-	RunRNG.set_seed(run_seed)
-	is_run_active = true
-	current_level = &""
-	emit_signal("run_started", run_seed, run_metadata.duplicate(true))
+    run_seed = seed
+    run_metadata = metadata.duplicate(true)
+    RunRNG.set_seed(run_seed)
+    is_run_active = true
+    current_level = &""
+    emit_signal("run_started", run_seed, run_metadata.duplicate(true))
 
 func end_run(results: Dictionary = {}) -> void:
-	if not is_run_active:
-		return
-	is_run_active = false
-	emit_signal("run_ended", results.duplicate(true))
+    if not is_run_active:
+        return
+    is_run_active = false
+    emit_signal("run_ended", results.duplicate(true))
 
 func set_level(level_path: String) -> void:
-	var normalized := StringName(level_path if level_path != null else "")
-	if current_level == normalized:
-		return
-	current_level = normalized
-	emit_signal("level_changed", String(current_level))
+    var normalized := StringName(level_path if level_path != null else "")
+    if current_level == normalized:
+        return
+    current_level = normalized
+    emit_signal("level_changed", String(current_level))
 
 func get_run_context() -> Dictionary:
-	return {
-		"seed": run_seed,
-		"metadata": run_metadata.duplicate(true),
-		"level": String(current_level),
-		"active": is_run_active,
-	}
+    return {
+        "seed": run_seed,
+        "metadata": run_metadata.duplicate(true),
+        "level": String(current_level),
+        "active": is_run_active,
+    }
 
 func reset() -> void:
-	is_run_active = false
-	current_level = &""
-	run_seed = 0
-	run_metadata.clear()
+    is_run_active = false
+    current_level = &""
+    run_seed = 0
+    run_metadata.clear()

--- a/godot/scripts/systems/RunRNG.gd
+++ b/godot/scripts/systems/RunRNG.gd
@@ -4,49 +4,42 @@ var _rng := RandomNumberGenerator.new()
 var _seed: int = 0
 
 func _ready() -> void:
-	if _seed == 0:
-		randomize()
+    if _seed == 0:
+        randomize()
 
 func randomize() -> void:
-	set_seed(generate_seed_from_time())
+    set_seed(generate_seed_from_time())
 
 func set_seed(seed_value: int) -> void:
-
     _seed = int(abs(seed_value))
     if _seed == 0:
         _seed = 1
     _rng.seed = _seed
 
-	_seed = int(abs(seed_value))
-	if _seed == 0:
-		_seed = 1
-	_rng.seed = _seed
-
-
 func get_seed() -> int:
-	return _seed
+    return _seed
 
 func randf() -> float:
-	return _rng.randf()
+    return _rng.randf()
 
 func randf_range(min_value: float, max_value: float) -> float:
-	return _rng.randf_range(min_value, max_value)
+    return _rng.randf_range(min_value, max_value)
 
 func randi() -> int:
-	return _rng.randi()
+    return _rng.randi()
 
 func randi_range(min_value: int, max_value: int) -> int:
-	return _rng.randi_range(min_value, max_value)
+    return _rng.randi_range(min_value, max_value)
 
 func shuffle(array: Array) -> void:
-	_rng.shuffle(array)
+    _rng.shuffle(array)
 
 func generate_seed_from_time() -> int:
-	var time_seed := int(Time.get_unix_time_from_system() * 1000.0)
-	time_seed &= 0x7fffffff
-	if time_seed == 0:
-		time_seed = 1
-	return time_seed
+    var time_seed := int(Time.get_unix_time_from_system() * 1000.0)
+    time_seed &= 0x7fffffff
+    if time_seed == 0:
+        time_seed = 1
+    return time_seed
 
 func get_state() -> Dictionary:
     return {
@@ -57,26 +50,7 @@ func get_state() -> Dictionary:
 func set_state(state_data: Dictionary) -> void:
     if state_data.is_empty():
         return
-    _seed = int(abs(state_data.get("seed", _seed)))
-    if _seed == 0:
-        _seed = 1
-    _rng.seed = _seed
+    set_seed(int(state_data.get("seed", _seed)))
     var rng_state = state_data.get("state")
     if rng_state != null:
         _rng.state = rng_state
-	return {
-		"seed": _seed,
-		"state": _rng.state,
-	}
-
-func set_state(state_data: Dictionary) -> void:
-	if state_data.is_empty():
-		return
-	_seed = int(abs(state_data.get("seed", _seed)))
-	if _seed == 0:
-		_seed = 1
-	_rng.seed = _seed
-	var rng_state = state_data.get("state")
-	if rng_state != null:
-		_rng.state = rng_state
-


### PR DESCRIPTION
## Summary
- clean up the RunRNG autoload so seeding, state restore, and helper methods work without duplicated logic
- normalize the GameState autoload so the run lifecycle seeds and resets the RNG consistently

## Testing
- godot --headless --version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e55d6b80c08329b5947e330885b7c3