### PR TITLE
Fix RNG autoload duplication

### DIFF
--- a/godot/scripts/combat/status_manager.gd
+++ b/godot/scripts/combat/status_manager.gd
@@ -8,7 +8,12 @@ signal self_damage_triggered(payload: Dictionary)
 
 @export var host: Node = null
 @export var immunity_flags: Dictionary = {}
-@export var instability_factor: float = 0.0 setget set_instability_factor, get_instability_factor
+
+@export var instability_factor: float = 0.0:
+    set(value):
+        set_instability_factor(value)
+    get:
+        return get_instability_factor()
 
 var _statuses: Dictionary = {}
 var _instability_factor: float = 0.0

--- a/godot/scripts/player/player_avatar.gd
+++ b/godot/scripts/player/player_avatar.gd
@@ -24,7 +24,13 @@ signal self_damage_taken(amount: float, payload: Dictionary)
 }
 @export var base_keywords: Array[StringName] = []
 
-@export var particle_class: ParticleClassDefinition = null setget set_particle_class
+var _particle_class: ParticleClassDefinition = null
+
+@export var particle_class: ParticleClassDefinition = null:
+    set(value):
+        set_particle_class(value)
+    get:
+        return _particle_class
 var current_stats: Dictionary = {}
 var current_keywords: Array[StringName] = []
 var mass: float = 1.0
@@ -55,22 +61,22 @@ func _ready() -> void:
 
 func set_particle_class(value: ParticleClassDefinition) -> void:
     _ensure_status_manager()
-    if value == particle_class:
+    if value == _particle_class:
         return
     _clear_abilities()
-    particle_class = value
-    if particle_class:
-        mass = particle_class.mass
-        charge = particle_class.charge
-        stability = particle_class.stability
+    _particle_class = value
+    if _particle_class:
+        mass = _particle_class.mass
+        charge = _particle_class.charge
+        stability = _particle_class.stability
         class_tags.clear()
-        for tag in particle_class.class_tags:
+        for tag in _particle_class.class_tags:
             if typeof(tag) == TYPE_STRING_NAME:
                 class_tags.append(tag)
             else:
                 class_tags.append(StringName(tag))
         _initialize_resources()
-        var loadout := particle_class.create_loadout()
+        var loadout := _particle_class.create_loadout()
         for slot in loadout:
             _set_ability(slot, loadout[slot])
     else:
@@ -81,7 +87,7 @@ func set_particle_class(value: ParticleClassDefinition) -> void:
         _initialize_resources()
     _update_instability_factor()
     _update_status_immunities()
-    emit_signal("class_changed", particle_class)
+    emit_signal("class_changed", _particle_class)
 
 func get_status_manager() -> StatusManager:
     return status_manager

--- a/godot/scripts/resources/particle_class.gd
+++ b/godot/scripts/resources/particle_class.gd
@@ -20,7 +20,13 @@ enum ElementGroup {
     RADIOACTIVE,
 }
 
-@export var element_group: ElementGroup = ElementGroup.NONE setget set_element_group
+var _element_group: ElementGroup = ElementGroup.NONE
+
+@export var element_group: ElementGroup = ElementGroup.NONE:
+    set(value):
+        set_element_group(value)
+    get:
+        return _element_group
 
 ## Baseline stats supplied by the particle class itself.
 @export var base_reactivity: float = 1.0
@@ -105,7 +111,7 @@ const GROUP_TRAIT_SCRIPTS := {
 }
 
 func set_element_group(value: ElementGroup) -> void:
-    element_group = value
+    _element_group = value
     # When the group changes we clear any previously assigned overrides so the
     # new default perks are used unless explicitly overridden again.
     if group_trait_scripts.is_empty():

--- a/godot/scripts/systems/GameState.gd
+++ b/godot/scripts/systems/GameState.gd
@@ -10,42 +10,42 @@ var run_seed: int = 0
 var run_metadata: Dictionary = {}
 
 func _ready() -> void:
-	if not is_run_active:
-		run_seed = RunRNG.generate_seed_from_time()
-		RunRNG.set_seed(run_seed)
-		run_metadata = {}
+    if not is_run_active:
+        run_seed = RunRNG.generate_seed_from_time()
+        RunRNG.set_seed(run_seed)
+        run_metadata = {}
 
 func start_new_run(seed: int = RunRNG.generate_seed_from_time(), metadata: Dictionary = {}) -> void:
-	run_seed = seed
-	run_metadata = metadata.duplicate(true)
-	RunRNG.set_seed(run_seed)
-	is_run_active = true
-	current_level = &""
-	emit_signal("run_started", run_seed, run_metadata.duplicate(true))
+    run_seed = seed
+    run_metadata = metadata.duplicate(true)
+    RunRNG.set_seed(run_seed)
+    is_run_active = true
+    current_level = &""
+    emit_signal("run_started", run_seed, run_metadata.duplicate(true))
 
 func end_run(results: Dictionary = {}) -> void:
-	if not is_run_active:
-		return
-	is_run_active = false
-	emit_signal("run_ended", results.duplicate(true))
+    if not is_run_active:
+        return
+    is_run_active = false
+    emit_signal("run_ended", results.duplicate(true))
 
 func set_level(level_path: String) -> void:
-	var normalized := StringName(level_path if level_path != null else "")
-	if current_level == normalized:
-		return
-	current_level = normalized
-	emit_signal("level_changed", String(current_level))
+    var normalized := StringName(level_path if level_path != null else "")
+    if current_level == normalized:
+        return
+    current_level = normalized
+    emit_signal("level_changed", String(current_level))
 
 func get_run_context() -> Dictionary:
-	return {
-		"seed": run_seed,
-		"metadata": run_metadata.duplicate(true),
-		"level": String(current_level),
-		"active": is_run_active,
-	}
+    return {
+        "seed": run_seed,
+        "metadata": run_metadata.duplicate(true),
+        "level": String(current_level),
+        "active": is_run_active,
+    }
 
 func reset() -> void:
-	is_run_active = false
-	current_level = &""
-	run_seed = 0
-	run_metadata.clear()
+    is_run_active = false
+    current_level = &""
+    run_seed = 0
+    run_metadata.clear()

--- a/godot/scripts/systems/RunRNG.gd
+++ b/godot/scripts/systems/RunRNG.gd
@@ -4,49 +4,42 @@ var _rng := RandomNumberGenerator.new()
 var _seed: int = 0
 
 func _ready() -> void:
-	if _seed == 0:
-		randomize()
+    if _seed == 0:
+        randomize()
 
 func randomize() -> void:
-	set_seed(generate_seed_from_time())
+    set_seed(generate_seed_from_time())
 
 func set_seed(seed_value: int) -> void:
-
     _seed = int(abs(seed_value))
     if _seed == 0:
         _seed = 1
     _rng.seed = _seed
 
-	_seed = int(abs(seed_value))
-	if _seed == 0:
-		_seed = 1
-	_rng.seed = _seed
-
-
 func get_seed() -> int:
-	return _seed
+    return _seed
 
 func randf() -> float:
-	return _rng.randf()
+    return _rng.randf()
 
 func randf_range(min_value: float, max_value: float) -> float:
-	return _rng.randf_range(min_value, max_value)
+    return _rng.randf_range(min_value, max_value)
 
 func randi() -> int:
-	return _rng.randi()
+    return _rng.randi()
 
 func randi_range(min_value: int, max_value: int) -> int:
-	return _rng.randi_range(min_value, max_value)
+    return _rng.randi_range(min_value, max_value)
 
 func shuffle(array: Array) -> void:
-	_rng.shuffle(array)
+    _rng.shuffle(array)
 
 func generate_seed_from_time() -> int:
-	var time_seed := int(Time.get_unix_time_from_system() * 1000.0)
-	time_seed &= 0x7fffffff
-	if time_seed == 0:
-		time_seed = 1
-	return time_seed
+    var time_seed := int(Time.get_unix_time_from_system() * 1000.0)
+    time_seed &= 0x7fffffff
+    if time_seed == 0:
+        time_seed = 1
+    return time_seed
 
 func get_state() -> Dictionary:
     return {
@@ -64,19 +57,3 @@ func set_state(state_data: Dictionary) -> void:
     var rng_state = state_data.get("state")
     if rng_state != null:
         _rng.state = rng_state
-	return {
-		"seed": _seed,
-		"state": _rng.state,
-	}
-
-func set_state(state_data: Dictionary) -> void:
-	if state_data.is_empty():
-		return
-	_seed = int(abs(state_data.get("seed", _seed)))
-	if _seed == 0:
-		_seed = 1
-	_rng.seed = _seed
-	var rng_state = state_data.get("state")
-	if rng_state != null:
-		_rng.state = rng_state
-


### PR DESCRIPTION
## Summary
- clean up the RunRNG autoload to remove duplicated function bodies and ensure consistent seeding/state management
- normalize GameState formatting and keep run metadata initialization consistent with the updated RNG helper

## Testing
- not run (Godot CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e55d6b80c08329b5947e330885b7c3